### PR TITLE
Add incognito window, find-in-page, and download center

### DIFF
--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -1190,12 +1190,17 @@
       "cmd-z": "browser::Undo",
       "cmd-shift-z": "browser::Redo",
       "cmd-a": "browser::SelectAll",
+      "cmd-f": "browser::FindInPage",
+      "cmd-g": "browser::FindNextInPage",
+      "cmd-shift-g": "browser::FindPreviousInPage",
       "cmd-l": "browser::FocusOmnibox",
       "cmd-t": "browser::NewTab",
       "cmd-w": "browser::CloseTab",
+      "cmd-shift-n": "workspace::NewIncognitoWindow",
       "cmd-shift-t": "browser::ReopenClosedTab",
       "cmd-shift-]": "browser::NextTab",
       "cmd-shift-[": "browser::PreviousTab",
+      "cmd-shift-j": "browser::ToggleDownloadCenter",
       "cmd-r": "browser::Reload",
       "cmd-[": "browser::GoBack",
       "cmd-]": "browser::GoForward",
@@ -1203,6 +1208,15 @@
       "f12": "browser::OpenDevTools",
       "cmd-s": "browser::ToggleSidebar",
       "cmd-shift-c": "browser::CopyUrl"
+    }
+  },
+  {
+    "context": "BrowserFindBar",
+    "use_key_equivalents": true,
+    "bindings": {
+      "enter": "browser::FindNextInPage",
+      "shift-enter": "browser::FindPreviousInPage",
+      "escape": "browser::CloseFindInPage"
     }
   },
   {

--- a/crates/browser/src/browser.rs
+++ b/crates/browser/src/browser.rs
@@ -9,7 +9,9 @@ mod cef_instance;
 mod client;
 mod context_menu_handler;
 mod display_handler;
+mod download_handler;
 mod events;
+mod find_handler;
 mod history;
 mod input;
 mod keycodes;
@@ -44,7 +46,10 @@ pub fn init(cx: &mut App) {
     match CefInstance::initialize(cx) {
         Ok(_) => {}
         Err(e) => {
-            log::error!("[browser] init() Failed to initialize CEF: {}. Browser mode will show placeholder.", e);
+            log::error!(
+                "[browser] init() Failed to initialize CEF: {}. Browser mode will show placeholder.",
+                e
+            );
         }
     }
 

--- a/crates/browser/src/browser_view/actions.rs
+++ b/crates/browser/src/browser_view/actions.rs
@@ -1,6 +1,13 @@
-use gpui::{Context, Window};
+use std::path::Path;
 
-use super::{BrowserView, Copy, Cut, Paste, Redo, SelectAll, Undo};
+use editor::{Editor, actions::SelectAll as EditorSelectAll};
+use gpui::{App, AppContext, Context, Entity, Focusable, Window};
+
+use super::{
+    BrowserView, CloseFindInPage, Copy, Cut, FindInPage, FindNextInPage, FindPreviousInPage, Paste,
+    Redo, SelectAll, ToggleDownloadCenter, Undo,
+};
+use crate::tab::BrowserTab;
 
 impl BrowserView {
     pub(super) fn handle_copy(&mut self, _: &Copy, _window: &mut Window, cx: &mut Context<Self>) {
@@ -15,12 +22,7 @@ impl BrowserView {
         }
     }
 
-    pub(super) fn handle_paste(
-        &mut self,
-        _: &Paste,
-        _window: &mut Window,
-        cx: &mut Context<Self>,
-    ) {
+    pub(super) fn handle_paste(&mut self, _: &Paste, _window: &mut Window, cx: &mut Context<Self>) {
         if let Some(tab) = self.active_tab() {
             tab.read(cx).paste();
         }
@@ -46,6 +48,207 @@ impl BrowserView {
     ) {
         if let Some(tab) = self.active_tab() {
             tab.read(cx).select_all();
+        }
+    }
+
+    pub(super) fn find_editor_is_focused(&self, window: &Window, cx: &App) -> bool {
+        self.find_editor
+            .as_ref()
+            .is_some_and(|editor| editor.focus_handle(cx).contains_focused(window, cx))
+    }
+
+    pub(super) fn ensure_find_editor(
+        &mut self,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> Entity<Editor> {
+        if let Some(editor) = self.find_editor.clone() {
+            return editor;
+        }
+
+        let editor = cx.new(|cx| {
+            let mut editor = Editor::single_line(window, cx);
+            editor.set_placeholder_text("Find in page", window, cx);
+            editor
+        });
+        let subscription = cx.subscribe(&editor, Self::handle_find_editor_event);
+        self._subscriptions.push(subscription);
+        self.find_editor = Some(editor.clone());
+        editor
+    }
+
+    pub(super) fn focus_find_editor(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        let editor = self.ensure_find_editor(window, cx);
+        window.focus(&editor.focus_handle(cx), cx);
+        editor.update(cx, |editor, cx| {
+            editor.select_all(&EditorSelectAll, window, cx);
+        });
+    }
+
+    pub(super) fn set_find_editor_text(
+        &mut self,
+        text: &str,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        if let Some(editor) = self.find_editor.clone() {
+            self.suppress_find_editor_event = true;
+            editor.update(cx, |editor, cx| {
+                editor.set_text(text.to_string(), window, cx);
+            });
+            self.suppress_find_editor_event = false;
+        }
+    }
+
+    pub(super) fn run_find(&mut self, forward: bool, find_next: bool, cx: &mut Context<Self>) {
+        if self.find_query.is_empty() {
+            if let Some(tab) = self.active_tab() {
+                tab.read(cx).stop_finding(true);
+            }
+            self.find_match_count = 0;
+            self.find_active_match_ordinal = 0;
+            return;
+        }
+
+        if let Some(tab) = self.active_tab() {
+            tab.read(cx)
+                .find_in_page(&self.find_query, forward, false, find_next);
+        }
+    }
+
+    pub(super) fn clear_find_for_tab_switch(
+        &mut self,
+        previous_tab: &Entity<BrowserTab>,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        if !self.find_visible && self.find_query.is_empty() {
+            return;
+        }
+
+        previous_tab.read(cx).stop_finding(true);
+        self.find_visible = false;
+        self.find_query.clear();
+        self.find_match_count = 0;
+        self.find_active_match_ordinal = 0;
+        self.set_find_editor_text("", window, cx);
+        cx.notify();
+    }
+
+    fn handle_find_editor_event(
+        &mut self,
+        _editor: Entity<Editor>,
+        event: &editor::EditorEvent,
+        cx: &mut Context<Self>,
+    ) {
+        if self.suppress_find_editor_event || !matches!(event, editor::EditorEvent::BufferEdited) {
+            return;
+        }
+
+        let Some(editor) = self.find_editor.clone() else {
+            return;
+        };
+
+        self.find_query = editor.read(cx).text(cx);
+        self.find_match_count = 0;
+        self.find_active_match_ordinal = 0;
+        self.run_find(true, false, cx);
+        cx.notify();
+    }
+
+    pub(super) fn handle_find_in_page(
+        &mut self,
+        _: &FindInPage,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.find_visible = true;
+        self.focus_find_editor(window, cx);
+        if !self.find_query.is_empty() {
+            self.run_find(true, false, cx);
+        }
+        cx.stop_propagation();
+        cx.notify();
+    }
+
+    pub(super) fn handle_find_next_in_page(
+        &mut self,
+        _: &FindNextInPage,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        if !self.find_visible {
+            self.find_visible = true;
+            self.focus_find_editor(window, cx);
+        }
+        self.run_find(true, true, cx);
+        cx.stop_propagation();
+        cx.notify();
+    }
+
+    pub(super) fn handle_find_previous_in_page(
+        &mut self,
+        _: &FindPreviousInPage,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        if !self.find_visible {
+            self.find_visible = true;
+            self.focus_find_editor(window, cx);
+        }
+        self.run_find(false, true, cx);
+        cx.stop_propagation();
+        cx.notify();
+    }
+
+    pub(super) fn handle_close_find_in_page(
+        &mut self,
+        _: &CloseFindInPage,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        if let Some(tab) = self.active_tab() {
+            tab.read(cx).stop_finding(true);
+        }
+        self.find_visible = false;
+        self.find_query.clear();
+        self.find_match_count = 0;
+        self.find_active_match_ordinal = 0;
+        self.set_find_editor_text("", window, cx);
+        window.focus(&self.focus_handle, cx);
+        cx.stop_propagation();
+        cx.notify();
+    }
+
+    pub(super) fn handle_toggle_download_center(
+        &mut self,
+        _: &ToggleDownloadCenter,
+        _window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.download_center_visible = !self.download_center_visible;
+        cx.notify();
+    }
+
+    pub(super) fn open_download_with_system(&mut self, id: u32, cx: &mut Context<Self>) {
+        let path = self
+            .downloads
+            .iter()
+            .find(|download| download.item.id == id)
+            .and_then(|download| download.item.full_path.clone());
+        if let Some(path) = path {
+            cx.open_with_system(Path::new(&path));
+        }
+    }
+
+    pub(super) fn reveal_download_in_finder(&mut self, id: u32, cx: &mut Context<Self>) {
+        let path = self
+            .downloads
+            .iter()
+            .find(|download| download.item.id == id)
+            .and_then(|download| download.item.full_path.clone());
+        if let Some(path) = path {
+            cx.reveal_path(Path::new(&path));
         }
     }
 }

--- a/crates/browser/src/browser_view/context_menu.rs
+++ b/crates/browser/src/browser_view/context_menu.rs
@@ -33,9 +33,9 @@ impl BrowserView {
 
             if let Some(link_url) = &context.link_url {
                 let url = link_url.clone();
-                let tab = tab.clone();
+                let tab_for_open_new_tab = tab.clone();
                 menu = menu.entry("Open Link in New Tab", None, move |_window, cx| {
-                    tab.update(cx, |_, cx| {
+                    tab_for_open_new_tab.update(cx, |_, cx| {
                         cx.emit(TabEvent::OpenNewTab(url.clone()));
                     });
                 });
@@ -43,6 +43,14 @@ impl BrowserView {
                 let url = link_url.clone();
                 menu = menu.entry("Copy Link Address", None, move |_window, cx| {
                     cx.write_to_clipboard(gpui::ClipboardItem::new_string(url.clone()));
+                });
+
+                let url = link_url.clone();
+                let tab_for_download = tab.clone();
+                menu = menu.entry("Download Link", None, move |_window, cx| {
+                    tab_for_download.update(cx, |tab, _| {
+                        tab.start_download(&url);
+                    });
                 });
 
                 menu = menu.separator();

--- a/crates/browser/src/browser_view/input.rs
+++ b/crates/browser/src/browser_view/input.rs
@@ -1,5 +1,5 @@
 use crate::input;
-use gpui::{point, Context, MouseButton, Window};
+use gpui::{Context, MouseButton, Window, point};
 
 use super::BrowserView;
 
@@ -52,9 +52,13 @@ impl BrowserView {
     pub(super) fn handle_key_down(
         &mut self,
         event: &gpui::KeyDownEvent,
-        _window: &mut Window,
+        window: &mut Window,
         cx: &mut Context<Self>,
     ) {
+        if self.find_editor_is_focused(window, cx) {
+            return;
+        }
+
         if let Some(tab) = self.active_tab() {
             tab.update(cx, |tab, _| {
                 tab.set_focus(true);
@@ -75,9 +79,13 @@ impl BrowserView {
     pub(super) fn handle_key_up(
         &mut self,
         event: &gpui::KeyUpEvent,
-        _window: &mut Window,
+        window: &mut Window,
         cx: &mut Context<Self>,
     ) {
+        if self.find_editor_is_focused(window, cx) {
+            return;
+        }
+
         if let Some(tab) = self.active_tab() {
             let keystroke = event.keystroke.clone();
             let tab = tab.clone();

--- a/crates/browser/src/browser_view/session.rs
+++ b/crates/browser/src/browser_view/session.rs
@@ -4,10 +4,14 @@ use gpui::{App, AppContext as _, Context, Task};
 use std::time::Duration;
 use util::ResultExt as _;
 
-use super::{BrowserView, TabBarMode};
+use super::{BrowserView, DownloadItemState, TabBarMode};
 
 impl BrowserView {
     pub(super) fn restore_tabs(&mut self, cx: &mut Context<Self>) -> bool {
+        if self.is_incognito_window {
+            return false;
+        }
+
         let saved = match session::restore() {
             Some(saved) if !saved.tabs.is_empty() => saved,
             _ => return false,
@@ -25,6 +29,7 @@ impl BrowserView {
                 tab.set_pinned(is_pinned);
                 tab
             });
+            self.configure_tab_request_context(&tab, cx);
             let subscription = cx.subscribe(&tab, Self::handle_tab_event);
             self._subscriptions.push(subscription);
             self.tabs.push(tab);
@@ -39,6 +44,19 @@ impl BrowserView {
         };
         self.sync_bookmark_bar_visibility(cx);
         true
+    }
+
+    pub(super) fn restore_downloads(&mut self) {
+        if self.is_incognito_window {
+            self.downloads.clear();
+            return;
+        }
+
+        self.downloads = session::restore_downloads()
+            .unwrap_or_default()
+            .into_iter()
+            .map(DownloadItemState::from_serialized)
+            .collect();
     }
 
     pub(super) fn serialize_tabs(&self, cx: &App) -> Option<String> {
@@ -70,24 +88,49 @@ impl BrowserView {
         serde_json::to_string(&data).log_err()
     }
 
+    pub(super) fn serialize_downloads(&self) -> Option<String> {
+        let downloads = self
+            .downloads
+            .iter()
+            .filter(|download| !download.is_incognito)
+            .map(DownloadItemState::to_serialized)
+            .collect::<Vec<_>>();
+        serde_json::to_string(&downloads).log_err()
+    }
+
     pub(super) fn schedule_save(&mut self, cx: &mut Context<Self>) {
+        if self.is_incognito_window {
+            return;
+        }
+
         self._schedule_save = Some(cx.spawn(async move |this, cx| {
             cx.background_executor()
                 .timer(Duration::from_millis(500))
                 .await;
 
-            let (tabs_json, history_json) = this
+            let (tabs_json, history_json, downloads_json) = this
                 .read_with(cx, |this, cx| {
-                    (this.serialize_tabs(cx), this.history.read(cx).serialize())
+                    if this.is_incognito_window {
+                        (None, None, None)
+                    } else {
+                        (
+                            this.serialize_tabs(cx),
+                            this.history.read(cx).serialize(),
+                            this.serialize_downloads(),
+                        )
+                    }
                 })
                 .ok()
-                .unwrap_or((None, None));
+                .unwrap_or((None, None, None));
 
             if let Some(json) = tabs_json {
                 session::save(json).await.log_err();
             }
             if let Some(json) = history_json {
                 session::save_history(json).await.log_err();
+            }
+            if let Some(json) = downloads_json {
+                session::save_downloads(json).await.log_err();
             }
 
             this.update(cx, |this, _| {
@@ -98,14 +141,22 @@ impl BrowserView {
     }
 
     pub(super) fn save_tabs_on_quit(&mut self, cx: &mut Context<Self>) -> Task<()> {
+        if self.is_incognito_window {
+            return Task::ready(());
+        }
+
         let tabs_json = self.serialize_tabs(cx);
         let history_json = self.history.read(cx).serialize();
+        let downloads_json = self.serialize_downloads();
         cx.background_spawn(async move {
             if let Some(json) = tabs_json {
                 session::save(json).await.log_err();
             }
             if let Some(json) = history_json {
                 session::save_history(json).await.log_err();
+            }
+            if let Some(json) = downloads_json {
+                session::save_downloads(json).await.log_err();
             }
         })
     }

--- a/crates/browser/src/browser_view/tab_strip.rs
+++ b/crates/browser/src/browser_view/tab_strip.rs
@@ -147,9 +147,9 @@ impl BrowserView {
                             menu = menu.separator();
                             {
                                 let view = view.clone();
-                                menu = menu.entry("Close Tab", None, move |_window, cx| {
+                                menu = menu.entry("Close Tab", None, move |window, cx| {
                                     view.update(cx, |this, cx| {
-                                        this.close_tab_at_inner(index, cx);
+                                        this.close_tab_at(index, window, cx);
                                     })
                                     .ok();
                                 });
@@ -351,9 +351,9 @@ impl BrowserView {
                                                 menu = menu.entry(
                                                     "Close Tab",
                                                     None,
-                                                    move |_window, cx| {
+                                                    move |window, cx| {
                                                         view.update(cx, |this, cx| {
-                                                            this.close_tab_at_inner(index, cx);
+                                                            this.close_tab_at(index, window, cx);
                                                         })
                                                         .ok();
                                                     },

--- a/crates/browser/src/download_handler.rs
+++ b/crates/browser/src/download_handler.rs
@@ -1,0 +1,201 @@
+//! CEF Download Handler
+//!
+//! Handles destination selection and progress updates for browser downloads.
+
+use crate::events::{BrowserEvent, DownloadUpdatedEvent, EventSender};
+use cef::{
+    Browser, DownloadHandler, DownloadItem, ImplBeforeDownloadCallback, ImplDownloadHandler,
+    ImplDownloadItem, WrapDownloadHandler, rc::Rc as _, wrap_download_handler,
+};
+use std::path::{Path, PathBuf};
+
+#[derive(Clone)]
+pub struct OsrDownloadHandler {
+    sender: EventSender,
+}
+
+impl OsrDownloadHandler {
+    pub fn new(sender: EventSender) -> Self {
+        Self { sender }
+    }
+
+    fn default_download_directory() -> PathBuf {
+        let preferred = paths::home_dir().join("Downloads");
+        if std::fs::create_dir_all(&preferred).is_ok() {
+            return preferred;
+        }
+
+        let fallback = paths::data_dir().join("browser_downloads");
+        if let Err(error) = std::fs::create_dir_all(&fallback) {
+            log::warn!(
+                "[browser] failed to create fallback download directory {}: {}",
+                fallback.display(),
+                error
+            );
+        }
+        fallback
+    }
+
+    fn file_name_for_download(
+        suggested_name: Option<&cef::CefString>,
+        download_item: Option<&mut DownloadItem>,
+    ) -> String {
+        if let Some(suggested_name) = suggested_name {
+            let suggested = suggested_name.to_string();
+            if !suggested.is_empty() {
+                return suggested;
+            }
+        }
+
+        if let Some(download_item) = download_item {
+            let suggested_userfree = download_item.suggested_file_name();
+            let suggested = cef::CefString::from(&suggested_userfree).to_string();
+            if !suggested.is_empty() {
+                return suggested;
+            }
+
+            let url_userfree = download_item.url();
+            let url_text = cef::CefString::from(&url_userfree).to_string();
+            if let Ok(parsed) = url::Url::parse(&url_text) {
+                if let Some(segment) = parsed
+                    .path_segments()
+                    .and_then(|segments| segments.last())
+                    .filter(|segment| !segment.is_empty())
+                {
+                    return segment.to_string();
+                }
+            }
+        }
+
+        String::from("download")
+    }
+
+    fn unique_download_path(directory: &Path, file_name: &str) -> PathBuf {
+        let file_name = Path::new(file_name)
+            .file_name()
+            .and_then(|name| name.to_str())
+            .filter(|name| !name.is_empty())
+            .unwrap_or("download");
+
+        let original_path = directory.join(file_name);
+        if !original_path.exists() {
+            return original_path;
+        }
+
+        let file_path = Path::new(file_name);
+        let stem = file_path
+            .file_stem()
+            .and_then(|stem| stem.to_str())
+            .filter(|stem| !stem.is_empty())
+            .unwrap_or("download");
+        let extension = file_path.extension().and_then(|ext| ext.to_str());
+
+        let mut attempt = 1u32;
+        loop {
+            let candidate_file_name = if let Some(extension) = extension {
+                format!("{stem} ({attempt}).{extension}")
+            } else {
+                format!("{stem} ({attempt})")
+            };
+
+            let candidate_path = directory.join(candidate_file_name);
+            if !candidate_path.exists() {
+                return candidate_path;
+            }
+
+            attempt += 1;
+        }
+    }
+}
+
+wrap_download_handler! {
+    pub struct DownloadHandlerBuilder {
+        handler: OsrDownloadHandler,
+    }
+
+    impl DownloadHandler {
+        fn can_download(
+            &self,
+            _browser: Option<&mut Browser>,
+            _url: Option<&cef::CefString>,
+            _request_method: Option<&cef::CefString>,
+        ) -> ::std::os::raw::c_int {
+            1
+        }
+
+        fn on_before_download(
+            &self,
+            _browser: Option<&mut Browser>,
+            download_item: Option<&mut DownloadItem>,
+            suggested_name: Option<&cef::CefString>,
+            callback: Option<&mut cef::BeforeDownloadCallback>,
+        ) -> ::std::os::raw::c_int {
+            let Some(callback) = callback else {
+                return 0;
+            };
+
+            let download_directory = OsrDownloadHandler::default_download_directory();
+            let file_name = OsrDownloadHandler::file_name_for_download(
+                suggested_name,
+                download_item,
+            );
+            let target_path =
+                OsrDownloadHandler::unique_download_path(&download_directory, &file_name);
+            let target_path_text = target_path.to_string_lossy().to_string();
+            let cef_target_path = cef::CefString::from(target_path_text.as_str());
+
+            callback.cont(Some(&cef_target_path), 0);
+            1
+        }
+
+        fn on_download_updated(
+            &self,
+            _browser: Option<&mut Browser>,
+            download_item: Option<&mut DownloadItem>,
+            _callback: Option<&mut cef::DownloadItemCallback>,
+        ) {
+            let Some(download_item) = download_item else {
+                return;
+            };
+
+            let full_path_userfree = download_item.full_path();
+            let full_path_text = cef::CefString::from(&full_path_userfree).to_string();
+            let full_path = if full_path_text.is_empty() {
+                None
+            } else {
+                Some(full_path_text)
+            };
+
+            let url_userfree = download_item.url();
+            let original_url_userfree = download_item.original_url();
+            let suggested_file_name_userfree = download_item.suggested_file_name();
+
+            let event = DownloadUpdatedEvent {
+                id: download_item.id(),
+                url: cef::CefString::from(&url_userfree).to_string(),
+                original_url: cef::CefString::from(&original_url_userfree).to_string(),
+                suggested_file_name: cef::CefString::from(&suggested_file_name_userfree)
+                    .to_string(),
+                full_path,
+                current_speed: download_item.current_speed(),
+                percent_complete: download_item.percent_complete(),
+                total_bytes: download_item.total_bytes(),
+                received_bytes: download_item.received_bytes(),
+                is_in_progress: download_item.is_in_progress() != 0,
+                is_complete: download_item.is_complete() != 0,
+                is_canceled: download_item.is_canceled() != 0,
+                is_interrupted: download_item.is_interrupted() != 0,
+            };
+
+            if let Err(error) = self.handler.sender.send(BrowserEvent::DownloadUpdated(event)) {
+                log::debug!("[browser] failed to send download updated event: {}", error);
+            }
+        }
+    }
+}
+
+impl DownloadHandlerBuilder {
+    pub fn build(handler: OsrDownloadHandler) -> cef::DownloadHandler {
+        Self::new(handler)
+    }
+}

--- a/crates/browser/src/events.rs
+++ b/crates/browser/src/events.rs
@@ -6,6 +6,31 @@
 use crate::context_menu_handler::ContextMenuContext;
 use std::sync::mpsc;
 
+#[derive(Debug, Clone)]
+pub struct FindResultEvent {
+    pub identifier: i32,
+    pub count: i32,
+    pub active_match_ordinal: i32,
+    pub final_update: bool,
+}
+
+#[derive(Debug, Clone)]
+pub struct DownloadUpdatedEvent {
+    pub id: u32,
+    pub url: String,
+    pub original_url: String,
+    pub suggested_file_name: String,
+    pub full_path: Option<String>,
+    pub current_speed: i64,
+    pub percent_complete: i32,
+    pub total_bytes: i64,
+    pub received_bytes: i64,
+    pub is_in_progress: bool,
+    pub is_complete: bool,
+    pub is_canceled: bool,
+    pub is_interrupted: bool,
+}
+
 pub enum BrowserEvent {
     AddressChanged(String),
     TitleChanged(String),
@@ -27,6 +52,8 @@ pub enum BrowserEvent {
         context: ContextMenuContext,
     },
     FaviconUrlChanged(Vec<String>),
+    FindResult(FindResultEvent),
+    DownloadUpdated(DownloadUpdatedEvent),
 }
 
 pub type EventSender = mpsc::Sender<BrowserEvent>;

--- a/crates/browser/src/find_handler.rs
+++ b/crates/browser/src/find_handler.rs
@@ -1,0 +1,54 @@
+//! CEF Find Handler
+//!
+//! Receives in-page find results from CEF and forwards them to BrowserTab.
+
+use crate::events::{BrowserEvent, EventSender, FindResultEvent};
+use cef::{Browser, FindHandler, ImplFindHandler, WrapFindHandler, rc::Rc as _, wrap_find_handler};
+
+#[derive(Clone)]
+pub struct OsrFindHandler {
+    sender: EventSender,
+}
+
+impl OsrFindHandler {
+    pub fn new(sender: EventSender) -> Self {
+        Self { sender }
+    }
+}
+
+wrap_find_handler! {
+    pub struct FindHandlerBuilder {
+        handler: OsrFindHandler,
+    }
+
+    impl FindHandler {
+        fn on_find_result(
+            &self,
+            _browser: Option<&mut Browser>,
+            identifier: ::std::os::raw::c_int,
+            count: ::std::os::raw::c_int,
+            _selection_rect: Option<&cef::Rect>,
+            active_match_ordinal: ::std::os::raw::c_int,
+            final_update: ::std::os::raw::c_int,
+        ) {
+            if let Err(error) = self
+                .handler
+                .sender
+                .send(BrowserEvent::FindResult(FindResultEvent {
+                identifier,
+                count,
+                active_match_ordinal,
+                final_update: final_update != 0,
+            }))
+            {
+                log::debug!("[browser] failed to send find result event: {}", error);
+            }
+        }
+    }
+}
+
+impl FindHandlerBuilder {
+    pub fn build(handler: OsrFindHandler) -> cef::FindHandler {
+        Self::new(handler)
+    }
+}

--- a/crates/browser/src/history.rs
+++ b/crates/browser/src/history.rs
@@ -81,6 +81,10 @@ impl BrowserHistory {
         &self.entries
     }
 
+    pub fn clear(&mut self) {
+        self.entries.clear();
+    }
+
     pub fn serialize(&self) -> Option<String> {
         serde_json::to_string(&self.entries).ok()
     }
@@ -164,7 +168,11 @@ impl BrowserHistory {
             })
             .collect();
 
-        results.sort_by(|a, b| b.score.partial_cmp(&a.score).unwrap_or(std::cmp::Ordering::Equal));
+        results.sort_by(|a, b| {
+            b.score
+                .partial_cmp(&a.score)
+                .unwrap_or(std::cmp::Ordering::Equal)
+        });
         results.truncate(max_results);
         results
     }

--- a/crates/browser/src/new_tab_page.rs
+++ b/crates/browser/src/new_tab_page.rs
@@ -2,7 +2,11 @@ use crate::omnibox::Omnibox;
 use gpui::{App, Entity, IntoElement, Styled, prelude::*};
 use ui::{Icon, IconName, IconSize, prelude::*};
 
-pub fn render_new_tab_page(omnibox: Option<&Entity<Omnibox>>, cx: &App) -> impl IntoElement {
+pub fn render_new_tab_page(
+    omnibox: Option<&Entity<Omnibox>>,
+    is_incognito_window: bool,
+    cx: &App,
+) -> impl IntoElement {
     let theme = cx.theme();
 
     div()
@@ -23,6 +27,28 @@ pub fn render_new_tab_page(omnibox: Option<&Entity<Omnibox>>, cx: &App) -> impl 
                         .size(IconSize::Custom(rems(4.0)))
                         .color(Color::Muted),
                 )
+                .when(is_incognito_window, |this| {
+                    this.child(
+                        div()
+                            .px_3()
+                            .py_1()
+                            .rounded_lg()
+                            .border_1()
+                            .border_color(theme.colors().border)
+                            .bg(theme.colors().element_background)
+                            .text_size(rems(0.8125))
+                            .text_color(theme.colors().text)
+                            .child("Incognito Window"),
+                    )
+                    .child(
+                        div()
+                            .text_size(rems(0.75))
+                            .text_color(theme.colors().text_muted)
+                            .text_center()
+                            .max_w(px(500.))
+                            .child("Your browsing activity in this window is not saved to browser history or session restore."),
+                    )
+                })
                 .when_some(omnibox.cloned(), |this, omnibox| {
                     this.child(div().w(px(500.)).child(omnibox))
                 }),

--- a/crates/browser/src/session.rs
+++ b/crates/browser/src/session.rs
@@ -7,6 +7,7 @@ use util::ResultExt as _;
 const BROWSER_TABS_KEY: &str = "browser_tabs";
 const BROWSER_HISTORY_KEY: &str = "browser_history";
 const BROWSER_BOOKMARKS_KEY: &str = "browser_bookmarks";
+const BROWSER_DOWNLOADS_KEY: &str = "browser_downloads";
 
 #[derive(Serialize, Deserialize)]
 pub struct SerializedBrowserTabs {
@@ -28,6 +29,23 @@ pub struct SerializedTab {
     pub favicon_url: Option<String>,
 }
 
+#[derive(Clone, Serialize, Deserialize)]
+pub struct SerializedDownloadItem {
+    pub id: u32,
+    pub url: String,
+    pub original_url: String,
+    pub suggested_file_name: String,
+    pub full_path: Option<String>,
+    pub current_speed: i64,
+    pub percent_complete: i32,
+    pub total_bytes: i64,
+    pub received_bytes: i64,
+    pub is_in_progress: bool,
+    pub is_complete: bool,
+    pub is_canceled: bool,
+    pub is_interrupted: bool,
+}
+
 pub fn restore() -> Option<SerializedBrowserTabs> {
     let json = KEY_VALUE_STORE.read_kvp(BROWSER_TABS_KEY).log_err()??;
     serde_json::from_str(&json).log_err()
@@ -40,9 +58,7 @@ pub async fn save(json: String) -> anyhow::Result<()> {
 }
 
 pub fn restore_history() -> Option<Vec<HistoryEntry>> {
-    let json = KEY_VALUE_STORE
-        .read_kvp(BROWSER_HISTORY_KEY)
-        .log_err()??;
+    let json = KEY_VALUE_STORE.read_kvp(BROWSER_HISTORY_KEY).log_err()??;
     serde_json::from_str(&json).log_err()
 }
 
@@ -62,5 +78,18 @@ pub fn restore_bookmarks() -> Option<BookmarkStore> {
 pub async fn save_bookmarks(json: String) -> anyhow::Result<()> {
     KEY_VALUE_STORE
         .write_kvp(BROWSER_BOOKMARKS_KEY.to_string(), json)
+        .await
+}
+
+pub fn restore_downloads() -> Option<Vec<SerializedDownloadItem>> {
+    let json = KEY_VALUE_STORE
+        .read_kvp(BROWSER_DOWNLOADS_KEY)
+        .log_err()??;
+    serde_json::from_str(&json).log_err()
+}
+
+pub async fn save_downloads(json: String) -> anyhow::Result<()> {
+    KEY_VALUE_STORE
+        .write_kvp(BROWSER_DOWNLOADS_KEY.to_string(), json)
         .await
 }

--- a/crates/zed/src/zed/app_menus.rs
+++ b/crates/zed/src/zed/app_menus.rs
@@ -1,7 +1,7 @@
 use gpui::{App, Menu, MenuItem, OsAction};
 use release_channel::ReleaseChannel;
 use terminal_view::terminal_panel;
-use zed_actions::{ToggleFocus as ToggleDebugPanel, dev};
+use zed_actions::{ToggleFocus as ToggleDebugPanel, dev, workspace as workspace_actions};
 
 pub fn app_menus(cx: &mut App) -> Vec<Menu> {
     use zed_actions::Quit;
@@ -113,6 +113,10 @@ pub fn app_menus(cx: &mut App) -> Vec<Menu> {
             items: vec![
                 MenuItem::action("New", workspace::NewFile),
                 MenuItem::action("New Window", workspace::NewWindow),
+                MenuItem::action(
+                    "New Incognito Window",
+                    workspace_actions::NewIncognitoWindow,
+                ),
                 MenuItem::separator(),
                 #[cfg(not(target_os = "macos"))]
                 MenuItem::action("Open File...", workspace::OpenFiles),

--- a/crates/zed_actions/src/lib.rs
+++ b/crates/zed_actions/src/lib.rs
@@ -232,6 +232,7 @@ pub mod workspace {
     actions!(
         workspace,
         [
+            NewIncognitoWindow,
             #[action(deprecated_aliases = ["editor::CopyPath", "project_panel::CopyPath"])]
             CopyPath,
             #[action(deprecated_aliases = ["editor::CopyRelativePath", "project_panel::CopyRelativePath"])]


### PR DESCRIPTION
## Summary
- add incognito window action, menu entry, and browser-mode wiring
- add find-in-page actions + find handler + overlay UI (cmd-f/cmd-g/shift-cmd-g)
- add download handler + download center overlay + context menu link download
- persist non-incognito downloads and clear incognito records
- add incognito new-tab visual indicator

## Validation
- cargo check -p browser
- ./script/bundle-mac-cef