### PR TITLE
Remove remaining collaboration shim leftovers

### DIFF
--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -2347,12 +2347,6 @@ impl Project {
         !self.is_local()
     }
 
-    /// Compatibility shim for upstream callsites after collab guest mode removal.
-    #[inline]
-    pub fn is_via_collab(&self) -> bool {
-        false
-    }
-
     #[inline]
     pub fn is_via_wsl_with_host_interop(&self, cx: &App) -> bool {
         matches!(
@@ -4151,15 +4145,6 @@ impl Project {
     pub fn remove_worktree(&mut self, id_to_remove: WorktreeId, cx: &mut Context<Self>) {
         self.worktree_store.update(cx, |worktree_store, cx| {
             worktree_store.remove_worktree(id_to_remove, cx);
-        });
-    }
-
-    /// NOTE: This function is dead code - it was only used by from_join_project_response
-    /// which has been removed (user-to-user collaboration).
-    #[allow(dead_code)]
-    fn add_worktree(&mut self, worktree: &Entity<Worktree>, cx: &mut Context<Self>) {
-        self.worktree_store.update(cx, |worktree_store, cx| {
-            worktree_store.add(worktree, cx);
         });
     }
 

--- a/crates/repl/src/repl_sessions_ui.rs
+++ b/crates/repl/src/repl_sessions_ui.rs
@@ -83,13 +83,7 @@ pub fn init(cx: &mut App) {
             cx.defer_in(window, |editor, _window, cx| {
                 let project = editor.project().cloned();
 
-                let is_valid_project = project
-                    .as_ref()
-                    .map(|project| {
-                        let p = project.read(cx);
-                        !p.is_via_collab()
-                    })
-                    .unwrap_or(false);
+                let is_valid_project = project.is_some();
 
                 if !is_valid_project {
                     return;

--- a/crates/title_bar/src/native_toolbar.rs
+++ b/crates/title_bar/src/native_toolbar.rs
@@ -236,13 +236,7 @@ impl NativeToolbarController {
         cx.notify();
     }
 
-    fn window_activation_changed(&mut self, _window: &mut Window, cx: &mut Context<Self>) {
-        self.workspace
-            .update(cx, |workspace, cx| {
-                workspace.update_active_view_for_followers(_window, cx);
-            })
-            .ok();
-    }
+    fn window_activation_changed(&mut self, _window: &mut Window, _cx: &mut Context<Self>) {}
 
     fn effective_active_worktree(&self, cx: &App) -> Option<Entity<project::Worktree>> {
         let project = self.project.read(cx);

--- a/crates/title_bar/src/title_bar.rs
+++ b/crates/title_bar/src/title_bar.rs
@@ -950,13 +950,7 @@ impl TitleBar {
         )
     }
 
-    fn window_activation_changed(&mut self, window: &mut Window, cx: &mut Context<Self>) {
-        self.workspace
-            .update(cx, |workspace, cx| {
-                workspace.update_active_view_for_followers(window, cx);
-            })
-            .ok();
-    }
+    fn window_activation_changed(&mut self, _window: &mut Window, _cx: &mut Context<Self>) {}
 
     #[cfg(not(target_os = "macos"))]
     fn render_connection_status(

--- a/crates/workspace/src/dock.rs
+++ b/crates/workspace/src/dock.rs
@@ -553,7 +553,6 @@ impl Dock {
                 }
                 cx.emit(Event::ZoomChanged);
                 workspace.dismiss_zoomed_items_to_reveal(Some(position), window, cx);
-                workspace.update_active_view_for_followers(window, cx)
             }
         })
         .detach();

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -4632,7 +4632,6 @@ impl Workspace {
         }
         self.zoomed_position = None;
         cx.emit(Event::ZoomChanged);
-        self.update_active_view_for_followers(window, cx);
         pane.update(cx, |pane, _| {
             pane.track_alternate_file_items();
         });
@@ -4651,9 +4650,7 @@ impl Workspace {
         self.last_active_center_pane = Some(pane.downgrade());
     }
 
-    fn handle_panel_focused(&mut self, window: &mut Window, cx: &mut Context<Self>) {
-        self.update_active_view_for_followers(window, cx);
-    }
+    fn handle_panel_focused(&mut self, _window: &mut Window, _cx: &mut Context<Self>) {}
 
     fn handle_pane_event(
         &mut self,
@@ -4708,7 +4705,6 @@ impl Workspace {
                 serialize_workspace = *focus_changed || pane != self.active_pane();
                 if pane == self.active_pane() {
                     self.active_item_path_changed(*focus_changed, window, cx);
-                    self.update_active_view_for_followers(window, cx);
                 } else if *local {
                     self.set_active_pane(pane, window, cx);
                 }
@@ -5359,10 +5355,6 @@ impl Workspace {
         self.leader_updated(CollaboratorId::Agent, window, cx);
     }
 
-    pub fn update_active_view_for_followers(&mut self, _window: &mut Window, _cx: &mut App) {
-        // No-op: Human collaboration features have been removed
-    }
-
     pub fn leader_for_pane(&self, pane: &Entity<Pane>) -> Option<CollaboratorId> {
         self.follower_states.iter().find_map(|(leader_id, state)| {
             if state.center_pane == *pane || state.dock_pane.as_ref() == Some(pane) {
@@ -5434,8 +5426,6 @@ impl Workspace {
 
     pub fn on_window_activation_changed(&mut self, window: &mut Window, cx: &mut Context<Self>) {
         if window.is_window_active() {
-            self.update_active_view_for_followers(window, cx);
-
             if let Some(database_id) = self.database_id {
                 cx.background_spawn(persistence::DB.update_timestamp(database_id))
                     .detach();

--- a/crates/zed/src/zed/quick_action_bar/repl_menu.rs
+++ b/crates/zed/src/zed/quick_action_bar/repl_menu.rs
@@ -38,14 +38,7 @@ impl QuickActionBar {
 
         let editor = self.active_editor()?;
 
-        let is_valid_project = editor
-            .read(cx)
-            .workspace()
-            .map(|workspace| {
-                let project = workspace.read(cx).project().read(cx);
-                !project.is_via_collab()
-            })
-            .unwrap_or(false);
+        let is_valid_project = editor.read(cx).workspace().is_some();
 
         if !is_valid_project {
             return None;


### PR DESCRIPTION
## Summary
- remove the `Project::is_via_collab()` compatibility shim that always returned `false`
- remove dead project worktree helper code left from removed user-to-user collaboration paths
- remove the no-op follower-update path in workspace/title bar/dock callsites
- simplify REPL project checks that previously depended on the removed collab shim

## Validation
- cargo check -p project -p workspace -p repl -p title_bar -p zed

Release Notes:

- Improved codebase clarity by removing dead collaboration-era shims and no-op call paths.
