### PR TITLE
browser: Use custom CEF 146 build with proprietary codecs

### DIFF
--- a/.github/workflows/release_glass.yml
+++ b/.github/workflows/release_glass.yml
@@ -94,37 +94,29 @@ jobs:
       - name: Generate licenses
         run: script/generate-licenses
 
-      # Cache CEF download to avoid re-downloading on each build
-      - name: Cache CEF framework
-        id: cache-cef
+      # Cache stock CEF 145 headers for building libcef_dll_wrapper
+      - name: Cache CEF build headers
+        id: cache-cef-headers
         uses: actions/cache@v4
         with:
           path: ~/.local/share/cef
-          key: cef-${{ matrix.cef_platform }}-v144
+          key: cef-headers-${{ matrix.cef_platform }}-v145
 
-      - name: Download and extract CEF
+      - name: Download CEF headers for build
         run: |
           CEF_PATH="$HOME/.local/share/cef"
           mkdir -p "$CEF_PATH"
-
-          # Set CEF_PATH for the build
           echo "CEF_PATH=$CEF_PATH" >> $GITHUB_ENV
 
-          # Check if CEF is already cached and valid
-          if [ -d "$CEF_PATH/Chromium Embedded Framework.framework" ]; then
-            echo "CEF framework found in cache"
+          if [ -f "$CEF_PATH/include/cef_version.h" ]; then
+            echo "CEF headers found in cache"
           else
-            echo "Downloading CEF from Spotify CDN..."
-
-            # CEF version must match what cef-rs expects (check Cargo.lock: cef version 145.1.1+145.0.23)
+            echo "Downloading stock CEF 145 headers from Spotify CDN..."
             CEF_VERSION="145.0.23"
             CEF_CDN="https://cef-builds.spotifycdn.com"
 
-            # Fetch index to get the exact filename with chromium version
-            echo "Fetching CEF index..."
             INDEX_JSON=$(curl -sL "$CEF_CDN/index.json")
 
-            # Find the minimal archive for the target platform
             if [ "${{ matrix.cef_platform }}" = "macosarm64" ]; then
               CEF_FILE=$(echo "$INDEX_JSON" | jq -r '.macosarm64.versions[] | select(.cef_version | startswith("'"$CEF_VERSION"'+")) | .files[] | select(.type == "minimal") | .name' | head -1)
               CEF_SHA1=$(echo "$INDEX_JSON" | jq -r '.macosarm64.versions[] | select(.cef_version | startswith("'"$CEF_VERSION"'+")) | .files[] | select(.type == "minimal") | .sha1' | head -1)
@@ -141,48 +133,50 @@ jobs:
             echo "Downloading: $CEF_FILE"
             curl -L -o "/tmp/cef.tar.bz2" "$CEF_CDN/$CEF_FILE"
 
-            # Verify SHA1
             DOWNLOADED_SHA1=$(shasum -a 1 /tmp/cef.tar.bz2 | cut -d' ' -f1)
             if [ "$DOWNLOADED_SHA1" != "$CEF_SHA1" ]; then
               echo "Error: SHA1 mismatch. Expected $CEF_SHA1, got $DOWNLOADED_SHA1"
               exit 1
             fi
-            echo "SHA1 verified: $CEF_SHA1"
 
-            # Extract archive
-            echo "Extracting CEF archive..."
-            cd /tmp
-            tar -xjf cef.tar.bz2
-
-            # Find extracted directory
+            cd /tmp && tar -xjf cef.tar.bz2
             EXTRACTED_DIR=$(ls -d cef_binary_* | head -1)
-            echo "Extracted to: $EXTRACTED_DIR"
 
-            # Copy Release folder contents (contains the framework on macOS)
+            # Copy headers, cmake, and build files (needed by cef-dll-sys)
             cp -R "/tmp/$EXTRACTED_DIR/Release/"* "$CEF_PATH/"
-
-            # Copy other needed files
             cp "/tmp/$EXTRACTED_DIR/CMakeLists.txt" "$CEF_PATH/" || true
             cp -R "/tmp/$EXTRACTED_DIR/cmake" "$CEF_PATH/" || true
             cp -R "/tmp/$EXTRACTED_DIR/include" "$CEF_PATH/" || true
             cp -R "/tmp/$EXTRACTED_DIR/libcef_dll" "$CEF_PATH/" || true
-
-            # Create archive.json for version tracking
             echo '{"type":"minimal","name":"'"$CEF_FILE"'","sha1":"'"$CEF_SHA1"'"}' > "$CEF_PATH/archive.json"
 
-            # Cleanup
             rm -rf /tmp/cef.tar.bz2 "/tmp/$EXTRACTED_DIR"
           fi
 
-          # Verify CEF was downloaded
-          if [ ! -d "$CEF_PATH/Chromium Embedded Framework.framework" ]; then
-            echo "Error: CEF framework not found after download"
-            ls -la "$CEF_PATH"
-            exit 1
-          fi
+          echo "CEF headers ready at: $CEF_PATH"
 
-          echo "CEF framework ready at: $CEF_PATH"
-          ls -la "$CEF_PATH"
+      - name: Download custom CEF framework with proprietary codecs
+        run: |
+          echo "Downloading custom CEF 146 build with proprietary codecs..."
+          CEF_CUSTOM_PATH="/tmp/cef-custom"
+          mkdir -p "$CEF_CUSTOM_PATH"
+
+          # Download from Glass-HQ/cef-builds release
+          gh release download v146.0.0-proprietary \
+            --repo Glass-HQ/cef-builds \
+            --pattern "cef-146-macosarm64-proprietary-codecs.tar.gz" \
+            --dir /tmp
+
+          echo "Extracting custom CEF framework..."
+          tar -xzf /tmp/cef-146-macosarm64-proprietary-codecs.tar.gz -C "$CEF_CUSTOM_PATH"
+
+          echo "CEF_CUSTOM_PATH=$CEF_CUSTOM_PATH" >> $GITHUB_ENV
+
+          echo "Custom CEF framework contents:"
+          ls "$CEF_CUSTOM_PATH/" | head -20
+          echo "... ($(ls "$CEF_CUSTOM_PATH/"*.dylib 2>/dev/null | wc -l) component dylibs)"
+        env:
+          GH_TOKEN: ${{ github.token }}
 
       - name: Build Glass
         run: |
@@ -259,9 +253,18 @@ jobs:
           # Create Frameworks directory
           mkdir -p "$APP_PATH/Contents/Frameworks"
 
-          # Copy CEF framework
-          echo "Copying CEF framework..."
-          cp -R "$CEF_PATH/Chromium Embedded Framework.framework" "$APP_PATH/Contents/Frameworks/"
+          # Copy custom CEF framework (with proprietary codecs)
+          echo "Copying custom CEF 146 framework with proprietary codecs..."
+          cp -R "$CEF_CUSTOM_PATH/Chromium Embedded Framework.framework" "$APP_PATH/Contents/Frameworks/"
+
+          # Copy component dylibs (CEF 146 component build produces ~514 separate dylibs)
+          echo "Copying CEF component dylibs..."
+          DYLIB_COUNT=0
+          for dylib in "$CEF_CUSTOM_PATH"/*.dylib; do
+            cp "$dylib" "$APP_PATH/Contents/Frameworks/"
+            DYLIB_COUNT=$((DYLIB_COUNT + 1))
+          done
+          echo "Copied $DYLIB_COUNT component dylibs to Frameworks/"
 
           # Create CEF helper app bundles
           APP_NAME="Glass"
@@ -498,23 +501,29 @@ jobs:
             echo "Signing with Developer ID: $SIGNING_IDENTITY"
             echo "Using entitlements: $ENTITLEMENTS"
 
-            # 1. Sign CEF framework first (innermost)
+            # 1. Sign CEF component dylibs first (innermost, no entitlements)
+            echo "Signing CEF component dylibs..."
+            for dylib in "$APP_PATH/Contents/Frameworks"/*.dylib; do
+              sign_file "$dylib" "$SIGNING_IDENTITY" ""
+            done
+
+            # 2. Sign CEF framework
             sign_framework "$CEF_FRAMEWORK" "$SIGNING_IDENTITY" ""
 
-            # 2. Sign CEF helper apps
+            # 3. Sign CEF helper apps
             for helper_suffix in "${HELPERS[@]}"; do
               HELPER_APP_NAME="${APP_NAME} ${helper_suffix}"
               HELPER_APP_PATH="$APP_PATH/Contents/Frameworks/${HELPER_APP_NAME}.app"
               sign_bundle "$HELPER_APP_PATH" "$SIGNING_IDENTITY" "$ENTITLEMENTS"
             done
 
-            # 3. Sign main app binaries
+            # 4. Sign main app binaries
             echo "Signing main app binaries..."
             sign_file "$APP_PATH/Contents/MacOS/cli" "$SIGNING_IDENTITY" "$ENTITLEMENTS"
             sign_file "$APP_PATH/Contents/MacOS/git" "$SIGNING_IDENTITY" "$ENTITLEMENTS"
             sign_file "$APP_PATH/Contents/MacOS/Glass" "$SIGNING_IDENTITY" "$ENTITLEMENTS"
 
-            # 4. Sign the main app bundle
+            # 5. Sign the main app bundle
             echo "Signing main app bundle..."
             /usr/bin/codesign -f -s "$SIGNING_IDENTITY" --options runtime \
               --entitlements "$ENTITLEMENTS" "$APP_PATH"
@@ -525,6 +534,11 @@ jobs:
 
           else
             echo "No signing certificate available, using ad-hoc signing"
+
+            # Ad-hoc sign CEF component dylibs
+            for dylib in "$APP_PATH/Contents/Frameworks"/*.dylib; do
+              codesign -f -s - "$dylib"
+            done
 
             # Ad-hoc sign CEF framework
             find "$CEF_FRAMEWORK" -type f \( -name "*.dylib" -o -perm +111 \) -exec codesign -f -s - {} \;

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2411,7 +2411,7 @@ dependencies = [
 [[package]]
 name = "cef"
 version = "145.4.0+145.0.26"
-source = "git+https://github.com/tauri-apps/cef-rs#96269bccc89ac392ecda7a4ca37577cdb04702f5"
+source = "git+https://github.com/Glass-HQ/cef-rs?branch=cef-146-compat#58b415410dd4f1d2e04829db98172792af6d265a"
 dependencies = [
  "cef-dll-sys",
  "libloading 0.9.0",
@@ -2422,7 +2422,7 @@ dependencies = [
 [[package]]
 name = "cef-dll-sys"
 version = "145.4.0+145.0.26"
-source = "git+https://github.com/tauri-apps/cef-rs#96269bccc89ac392ecda7a4ca37577cdb04702f5"
+source = "git+https://github.com/Glass-HQ/cef-rs?branch=cef-146-compat#58b415410dd4f1d2e04829db98172792af6d265a"
 dependencies = [
  "anyhow",
  "cmake",
@@ -4433,7 +4433,7 @@ checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
 [[package]]
 name = "download-cef"
 version = "2.3.0"
-source = "git+https://github.com/tauri-apps/cef-rs#96269bccc89ac392ecda7a4ca37577cdb04702f5"
+source = "git+https://github.com/Glass-HQ/cef-rs?branch=cef-146-compat#58b415410dd4f1d2e04829db98172792af6d265a"
 dependencies = [
  "bzip2",
  "clap",
@@ -15836,7 +15836,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fb391ac70462b3097a755618fbf9c8f95ecc1eb379a414f7b46f202ed10db1f"
 dependencies = [
  "cc",
- "windows-targets 0.52.6",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -17748,7 +17748,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/crates/browser/Cargo.toml
+++ b/crates/browser/Cargo.toml
@@ -38,7 +38,7 @@ workspace_modes.workspace = true
 zed_actions.workspace = true
 
 # CEF browser integration
-cef = { git = "https://github.com/tauri-apps/cef-rs", default-features = false }
+cef = { git = "https://github.com/Glass-HQ/cef-rs", branch = "cef-146-compat", default-features = false }
 parking_lot.workspace = true
 image.workspace = true
 log.workspace = true

--- a/crates/browser/src/cef_instance.rs
+++ b/crates/browser/src/cef_instance.rs
@@ -337,6 +337,27 @@ impl CefInstance {
             }
         }
 
+        // Set framework_dir_path and main_bundle_path when not running from a bundle
+        // (e.g. cargo run with CEF_PATH)
+        #[cfg(target_os = "macos")]
+        {
+            if let Some(cef_dir) = resolve_cef_dir_from_env() {
+                let fw_path = cef_dir.join("Chromium Embedded Framework.framework");
+                if fw_path.exists() {
+                    if let Some(fw_str) = fw_path.to_str() {
+                        settings.framework_dir_path = cef::CefString::from(fw_str);
+                    }
+                }
+                if let Ok(exe_path) = std::env::current_exe() {
+                    if let Some(exe_dir) = exe_path.parent() {
+                        if let Some(dir_str) = exe_dir.to_str() {
+                            settings.main_bundle_path = cef::CefString::from(dir_str);
+                        }
+                    }
+                }
+            }
+        }
+
         let cache_dir = paths::data_dir().join("browser_cache");
         if let Err(e) = std::fs::create_dir_all(&cache_dir) {
             log::warn!(


### PR DESCRIPTION
## Summary

- Switch from stock CEF 145 (Spotify CDN, no codecs) to a custom CEF 146 build with proprietary codecs (H.264, AAC, Widevine) hosted at [Glass-HQ/cef-builds](https://github.com/Glass-HQ/cef-builds/releases/tag/v146.0.0-proprietary)
- Point `cef` dependency at [Glass-HQ/cef-rs](https://github.com/Glass-HQ/cef-rs/tree/cef-146-compat) fork with CEF 146 ABI compatibility (single struct field addition)
- Add `framework_dir_path` and `main_bundle_path` settings for non-bundle `cargo run` dev workflow
- Update release workflow to bundle 514 component dylibs and sign them

## How it works

**Build time:** Stock CEF 145 headers are still downloaded from Spotify CDN for compiling `libcef_dll_wrapper.a` (the C API is ABI-compatible between 145 and 146 for all functions we use).

**Bundle time:** The custom CEF 146 framework + 514 component dylibs are downloaded from Glass-HQ/cef-builds and placed in `Contents/Frameworks/`.

**Runtime:** The CEF 146 framework loads its component dylibs via `@rpath`, which resolves to `Contents/Frameworks/` in a `.app` bundle.

## Cleanup path

When upstream `tauri-apps/cef-rs` releases CEF 146 bindings:
1. Switch `cef` dependency back to `tauri-apps/cef-rs`
2. Remove the `branch = "cef-146-compat"` specifier
3. The Glass-HQ/cef-rs fork can be archived

When a monolithic CEF build (non-component) is available:
1. Update the tarball in Glass-HQ/cef-builds
2. Remove the component dylib copy/sign steps from the workflow

## Test plan

- [x] Verified streaming platforms work with custom CEF build locally (`cargo run` with `CEF_PATH`)
- [x] Verified codec support via browser codec test pages
- [ ] Trigger release workflow and verify DMG installs and streams correctly

Release Notes:

- Added proprietary codec support (H.264, AAC, Widevine) to the built-in browser, enabling streaming platform playback