### PR TITLE
Enable mimalloc in release builds to fix CEF allocator crash

### DIFF
--- a/.github/workflows/release_glass.yml
+++ b/.github/workflows/release_glass.yml
@@ -182,7 +182,7 @@ jobs:
         run: |
           export ZED_BUNDLE=true
           export CXXFLAGS="-stdlib=libc++"
-          cargo build --release --package zed --package cli --target ${{ matrix.target }}
+          cargo build --release --features mimalloc --package zed --package cli --target ${{ matrix.target }}
           cargo build --release --package remote_server --target ${{ matrix.target }}
 
       - name: Build glass_helper

--- a/script/bundle-mac-cef
+++ b/script/bundle-mac-cef
@@ -44,7 +44,7 @@ echo "Building for: $target_triple ($BUILD_TYPE)"
 
 # Build the main application
 echo "Building zed..."
-cargo build $BUILD_FLAG --package zed --target $target_triple
+cargo build $BUILD_FLAG --features mimalloc --package zed --target $target_triple
 
 # Build the helper executable
 echo "Building glass_helper..."


### PR DESCRIPTION
## Summary

- Enable the existing `mimalloc` feature flag in release builds (`release_glass.yml` and `bundle-mac-cef`)
- Fixes repeated `EXC_BREAKPOINT (SIGTRAP)` crashes in production where CEF's PartitionAlloc malloc zone intercepts Rust's system `realloc` calls during GPUI taffy layout

## Root Cause

CEF registers PartitionAlloc as a macOS malloc zone. Without mimalloc, Rust uses the system allocator, and when taffy's `SlotMap` grows during project panel `UniformList` rendering, the `realloc` goes through `malloc_zone_realloc` → CEF's zone handler → SIGTRAP assertion on memory CEF didn't allocate.

With mimalloc as `#[global_allocator]`, all Rust allocations use MiMalloc's own memory pool, bypassing system malloc zones entirely.

## Test plan

- [ ] Build release with `--features mimalloc` and verify no crash during project panel rendering
- [ ] Verify CEF browser functionality still works (page loads, navigation)

Release Notes:

- Fixed crash caused by CEF's PartitionAlloc conflicting with the system memory allocator during layout rendering

🤖 Generated with [Claude Code](https://claude.com/claude-code)