### PR TITLE
browser: Fix CEF bundle path detection, add pinned tab persistence across windows

### DIFF
--- a/.rules
+++ b/.rules
@@ -1,3 +1,7 @@
+# Repository
+
+This is a fork of zed-industries/zed. **NEVER push branches, create PRs, or interact with the upstream `zed-industries/zed` repo.** All branches and PRs must target `Glass-HQ/Glass` only. When using `gh pr create`, always pass `--repo Glass-HQ/Glass`.
+
 # Rust coding guidelines
 
 * Prioritize code correctness and clarity. Speed and efficiency are secondary priorities unless otherwise specified.

--- a/crates/browser/src/browser_view/tabs.rs
+++ b/crates/browser/src/browser_view/tabs.rs
@@ -226,7 +226,7 @@ impl BrowserView {
         }
 
         self.update_toolbar_active_tab(window, cx);
-        self.focus_omnibox_if_new_tab(window, cx);
+        self.request_new_tab_search_focus(cx);
         self.schedule_save(cx);
         cx.notify();
     }
@@ -307,7 +307,7 @@ impl BrowserView {
     ) {
         self.add_tab(cx);
         self.update_toolbar_active_tab(window, cx);
-        self.focus_omnibox_if_new_tab(window, cx);
+        self.request_new_tab_search_focus(cx);
         cx.notify();
     }
 
@@ -361,7 +361,7 @@ impl BrowserView {
             self.add_tab(cx);
 
             self.update_toolbar_active_tab(window, cx);
-            self.focus_omnibox_if_new_tab(window, cx);
+            self.request_new_tab_search_focus(cx);
             self.schedule_save(cx);
             cx.notify();
             return;
@@ -379,7 +379,7 @@ impl BrowserView {
         self.activate_tab_for_close(cx);
 
         self.update_toolbar_active_tab(window, cx);
-        self.focus_omnibox_if_new_tab(window, cx);
+        self.request_new_tab_search_focus(cx);
         self.schedule_save(cx);
         cx.notify();
     }

--- a/crates/browser/src/cef_instance.rs
+++ b/crates/browser/src/cef_instance.rs
@@ -337,21 +337,27 @@ impl CefInstance {
             }
         }
 
-        // Set framework_dir_path and main_bundle_path when not running from a bundle
-        // (e.g. cargo run with CEF_PATH)
+        // Set framework_dir_path and main_bundle_path only when not running from a
+        // bundle (e.g. cargo run with CEF_PATH). When running from a .app bundle, CEF
+        // discovers the bundle automatically via NSBundle; setting main_bundle_path to
+        // the wrong directory (Contents/MacOS/) would cause CEF to fail reading the
+        // CFBundleIdentifier.
         #[cfg(target_os = "macos")]
         {
-            if let Some(cef_dir) = resolve_cef_dir_from_env() {
-                let fw_path = cef_dir.join("Chromium Embedded Framework.framework");
-                if fw_path.exists() {
-                    if let Some(fw_str) = fw_path.to_str() {
-                        settings.framework_dir_path = cef::CefString::from(fw_str);
+            let running_from_bundle = CEF_LIBRARY_LOADER.lock().is_some();
+            if !running_from_bundle {
+                if let Some(cef_dir) = resolve_cef_dir_from_env() {
+                    let fw_path = cef_dir.join("Chromium Embedded Framework.framework");
+                    if fw_path.exists() {
+                        if let Some(fw_str) = fw_path.to_str() {
+                            settings.framework_dir_path = cef::CefString::from(fw_str);
+                        }
                     }
-                }
-                if let Ok(exe_path) = std::env::current_exe() {
-                    if let Some(exe_dir) = exe_path.parent() {
-                        if let Some(dir_str) = exe_dir.to_str() {
-                            settings.main_bundle_path = cef::CefString::from(dir_str);
+                    if let Ok(exe_path) = std::env::current_exe() {
+                        if let Some(exe_dir) = exe_path.parent() {
+                            if let Some(dir_str) = exe_dir.to_str() {
+                                settings.main_bundle_path = cef::CefString::from(dir_str);
+                            }
                         }
                     }
                 }

--- a/crates/browser/src/session.rs
+++ b/crates/browser/src/session.rs
@@ -5,6 +5,7 @@ use serde::{Deserialize, Serialize};
 use util::ResultExt as _;
 
 const BROWSER_TABS_KEY: &str = "browser_tabs";
+const BROWSER_PINNED_TABS_KEY: &str = "browser_pinned_tabs";
 const BROWSER_HISTORY_KEY: &str = "browser_history";
 const BROWSER_BOOKMARKS_KEY: &str = "browser_bookmarks";
 const BROWSER_DOWNLOADS_KEY: &str = "browser_downloads";
@@ -54,6 +55,19 @@ pub fn restore() -> Option<SerializedBrowserTabs> {
 pub async fn save(json: String) -> anyhow::Result<()> {
     KEY_VALUE_STORE
         .write_kvp(BROWSER_TABS_KEY.to_string(), json)
+        .await
+}
+
+pub fn restore_pinned_tabs() -> Option<Vec<SerializedTab>> {
+    let json = KEY_VALUE_STORE
+        .read_kvp(BROWSER_PINNED_TABS_KEY)
+        .log_err()??;
+    serde_json::from_str(&json).log_err()
+}
+
+pub async fn save_pinned_tabs(json: String) -> anyhow::Result<()> {
+    KEY_VALUE_STORE
+        .write_kvp(BROWSER_PINNED_TABS_KEY.to_string(), json)
         .await
 }
 

--- a/script/bundle-mac-cef
+++ b/script/bundle-mac-cef
@@ -71,6 +71,13 @@ cp "$BINARY_PATH" "$APP_PATH/Contents/MacOS/$APP_NAME"
 echo "Copying CEF framework..."
 cp -R "$CEF_PATH/Chromium Embedded Framework.framework" "$APP_PATH/Contents/Frameworks/"
 
+# Copy component dylibs (CEF 146+ component builds produce separate dylibs)
+DYLIB_COUNT=$(ls "$CEF_PATH"/*.dylib 2>/dev/null | wc -l | tr -d ' ')
+if [[ "$DYLIB_COUNT" -gt 0 ]]; then
+    echo "Copying $DYLIB_COUNT CEF component dylibs..."
+    cp "$CEF_PATH"/*.dylib "$APP_PATH/Contents/Frameworks/"
+fi
+
 # Helper types required by CEF
 HELPERS=("Helper" "Helper (GPU)" "Helper (Renderer)" "Helper (Plugin)" "Helper (Alerts)")
 
@@ -227,7 +234,11 @@ echo "APPL????" > "$APP_PATH/Contents/PkgInfo"
 
 # Ad-hoc code sign (required for running on macOS)
 echo "Code signing bundle..."
-# Sign helpers first (inside out)
+# Sign component dylibs first (innermost)
+for dylib in "$APP_PATH/Contents/Frameworks"/*.dylib; do
+    [ -f "$dylib" ] && codesign --force --sign - "$dylib"
+done
+# Sign helpers (inside out)
 for helper_suffix in "${HELPERS[@]}"; do
     HELPER_APP_NAME="${APP_NAME} ${helper_suffix}"
     HELPER_APP_PATH="$APP_PATH/Contents/Frameworks/${HELPER_APP_NAME}.app"


### PR DESCRIPTION
## Summary
- Fix CEF initialization crash (`DCHECK !bundle_id.empty()`) when running from a .app bundle by only setting `main_bundle_path`/`framework_dir_path` when not in a bundle context
- Update `bundle-mac-cef` script to copy and code-sign CEF 146 component dylibs, and build with `--features mimalloc`
- Add pinned tab persistence so secondary browser windows restore pinned tabs while the primary window restores the full session
- Replace `focus_omnibox_if_new_tab` with deferred native search field focus to fix timing issues
- Add upstream repo warning to `.rules`

## Test plan
- [x] Built release bundle with `script/bundle-mac-cef release`
- [x] Launched app from bundle — CEF initializes correctly, browser works
- [x] Verified pinned tabs persist across app restarts
- [x] Verified new tab search field receives focus correctly

Release Notes:

- N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)