### PR TITLE
Fix CEF shutdown crash, native menu offsets, and pinned tab handling

### DIFF
--- a/crates/agent_ui/src/acp/thread_view/active_thread.rs
+++ b/crates/agent_ui/src/acp/thread_view/active_thread.rs
@@ -3102,7 +3102,9 @@ impl AcpThreadView {
             use gpui::{NativeMenuItem, show_native_popup_menu};
 
             let mut items = vec![NativeMenuItem::action("Change Thinking Effort").enabled(false)];
-            let mut effort_values: Vec<String> = Vec::new();
+            // Pad with an empty entry to account for the disabled header item,
+            // which still gets an action index in the native menu.
+            let mut effort_values: Vec<String> = vec![String::new()];
 
             for effort_level in supported_effort_levels.clone() {
                 let is_selected = selected
@@ -3381,38 +3383,39 @@ impl AcpThreadView {
                         window,
                         cx,
                         move |index, window, cx| {
+                            // Index 0 is the disabled "Context" header
                             match index {
-                                0 => {
+                                1 => {
                                     me.focus_handle(cx).focus(window, cx);
                                     me.update(cx, |editor, cx| {
                                         editor.insert_context_type("file", window, cx);
                                     });
                                 }
-                                1 => {
+                                2 => {
                                     me.focus_handle(cx).focus(window, cx);
                                     me.update(cx, |editor, cx| {
                                         editor.insert_context_type("symbol", window, cx);
                                     });
                                 }
-                                2 => {
+                                3 => {
                                     me.focus_handle(cx).focus(window, cx);
                                     me.update(cx, |editor, cx| {
                                         editor.insert_context_type("thread", window, cx);
                                     });
                                 }
-                                3 => {
+                                4 => {
                                     me.focus_handle(cx).focus(window, cx);
                                     me.update(cx, |editor, cx| {
                                         editor.insert_context_type("rule", window, cx);
                                     });
                                 }
-                                4 => {
+                                5 => {
                                     me.focus_handle(cx).focus(window, cx);
                                     me.update(cx, |editor, cx| {
                                         editor.add_images_from_picker(window, cx);
                                     });
                                 }
-                                5 => {
+                                6 => {
                                     window.dispatch_action(
                                         zed_actions::agent::AddSelectionToThread.boxed_clone(),
                                         cx,

--- a/crates/agent_ui/src/agent_configuration.rs
+++ b/crates/agent_ui/src/agent_configuration.rs
@@ -449,7 +449,8 @@ impl AgentConfiguration {
                         window,
                         cx,
                         move |index, window, cx| {
-                            if index == 0 {
+                            // Index 0 is the disabled "Compatible APIs" header
+                            if index == 1 {
                                 workspace
                                     .update(cx, |workspace, cx| {
                                         AddLlmProviderModal::toggle(
@@ -1226,7 +1227,8 @@ impl AgentConfiguration {
                                         .detach_and_log_err(cx);
                                 }
                             }
-                            2 => {
+                            // Index 2 is the disabled "Learn More" header
+                            3 => {
                                 window.dispatch_action(
                                     Box::new(OpenBrowser {
                                         url: zed_urls::agent_server_docs(cx),
@@ -1234,7 +1236,7 @@ impl AgentConfiguration {
                                     cx,
                                 );
                             }
-                            3 => {
+                            4 => {
                                 window.dispatch_action(
                                     Box::new(OpenBrowser {
                                         url: "https://agentclientprotocol.com/".into(),

--- a/crates/agent_ui/src/agent_panel.rs
+++ b/crates/agent_ui/src/agent_panel.rs
@@ -2205,6 +2205,7 @@ impl AgentPanel {
 
             if thread_with_messages | text_thread_with_messages {
                 items.push(NativeMenuItem::action("Current Thread").enabled(false));
+                actions.push(Box::new(|_, _| {}));
 
                 if let Some(text_thread_view) = text_thread_view.clone() {
                     items.push(NativeMenuItem::action("Regenerate Thread Title"));
@@ -2224,6 +2225,7 @@ impl AgentPanel {
             }
 
             items.push(NativeMenuItem::action("MCP Servers").enabled(false));
+            actions.push(Box::new(|_, _| {}));
             items.push(NativeMenuItem::action("View Server Extensions"));
             actions.push(Box::new({
                 let focus_handle = focus_handle.clone();
@@ -2462,6 +2464,7 @@ impl AgentPanel {
                                             NativeMenuItem::action("Recently Updated")
                                                 .enabled(false),
                                         );
+                                        actions.push(Box::new(|_, _| {}));
                                         for entry in entries {
                                             let title = entry
                                                 .title
@@ -2500,6 +2503,7 @@ impl AgentPanel {
                                             NativeMenuItem::action("Recent Text Threads")
                                                 .enabled(false),
                                         );
+                                        actions.push(Box::new(|_, _| {}));
                                         for entry in entries {
                                             let title = if entry.title.is_empty() {
                                                 SharedString::new_static(DEFAULT_THREAD_TITLE)
@@ -2698,6 +2702,7 @@ impl AgentPanel {
 
             items.push(NativeMenuItem::separator());
             items.push(NativeMenuItem::action("External Agents").enabled(false));
+            actions.push(Box::new(|_, _| {}));
 
             items.push(NativeMenuItem::action("Claude Code"));
             actions.push(Box::new({

--- a/crates/browser/src/browser_view/navigation.rs
+++ b/crates/browser/src/browser_view/navigation.rs
@@ -43,9 +43,13 @@ impl BrowserView {
         _window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        if let Some(tab) = self.active_tab() {
+        if let Some(tab) = self.active_tab().cloned() {
             tab.update(cx, |tab, _| {
-                tab.reload();
+                if tab.is_suspended() {
+                    tab.resume();
+                } else {
+                    tab.reload();
+                }
             });
         }
     }


### PR DESCRIPTION
## Summary

- **browser:** Fix DCHECK crash (`all_.empty()` in `browser_context.cc`) on app quit by moving CEF browser handles from `BrowserTab` to a centralized global registry (`BROWSER_HANDLES`). During shutdown, `close_all_browsers()` takes all handles, force-closes them, and drops the Rust refs — releasing CEF's `BrowserContext` ref counts before `cef::shutdown()`. Previously, GPUI entity drops didn't complete before the quit future ran, leaving live browser refs that caused the assertion.
- **browser:** Add pinned tab suspend/resume — closing a pinned tab suspends it instead of destroying it; tab switching and reload resume suspended tabs.
- **agent_ui:** Fix native menu action index offsets — disabled header items consumed action indices but had no corresponding handler entries, causing off-by-one dispatch for all subsequent items.

## Test plan

- [ ] Open a browser tab, quit the app — no DCHECK crash or trace trap
- [ ] Pin a tab, close it — tab suspends (muted, hidden) rather than being destroyed
- [ ] Switch back to the pinned tab — it resumes correctly
- [ ] Verify native menu items in agent panel (new thread, context menu, thinking effort) dispatch to correct handlers

Release Notes:

- Fixed crash on app quit caused by CEF browser handles not being released before shutdown
- Fixed pinned tabs being destroyed instead of suspended on close
- Fixed native menu items dispatching to wrong handlers due to index offset

🤖 Generated with [Claude Code](https://claude.com/claude-code)