### PR TITLE
Fix CEF focus retention, project selector mode switching, and sidebar state

### DIFF
--- a/crates/workspace_modes/src/mode_view_registry.rs
+++ b/crates/workspace_modes/src/mode_view_registry.rs
@@ -9,6 +9,9 @@ use collections::HashMap;
 use gpui::{AnyView, App, FocusHandle, Global};
 use std::sync::Arc;
 
+/// Callback invoked when a mode is deactivated (switched away from).
+pub type ModeDeactivateCallback = Arc<dyn Fn(&mut App) + Send + Sync>;
+
 /// A view that can be displayed for a workspace mode.
 ///
 /// Mode views are registered with the `ModeViewRegistry` and retrieved by
@@ -22,6 +25,8 @@ pub struct RegisteredModeView {
     pub titlebar_center_view: Option<AnyView>,
     /// Optional sidebar view shown in the unified native sidebar when this mode is active
     pub sidebar_view: Option<AnyView>,
+    /// Optional callback invoked when this mode is deactivated
+    pub on_deactivate: Option<ModeDeactivateCallback>,
 }
 
 /// Factory function that creates a new mode view instance.

--- a/crates/workspace_modes/src/workspace_modes.rs
+++ b/crates/workspace_modes/src/workspace_modes.rs
@@ -20,7 +20,9 @@ mod mode_switcher;
 mod mode_view_registry;
 
 pub use mode_switcher::ModeSwitcher;
-pub use mode_view_registry::{ModeViewFactory, ModeViewRegistry, RegisteredModeView};
+pub use mode_view_registry::{
+    ModeDeactivateCallback, ModeViewFactory, ModeViewRegistry, RegisteredModeView,
+};
 
 use gpui::{App, Global, actions};
 use schemars::JsonSchema;


### PR DESCRIPTION
## Summary

- **CEF focus fix**: Added `ModeDeactivateCallback` to the mode view registry so modes can clean up on deactivation. Browser registers a callback that calls `set_focus(false)` on the active CEF tab, eliminating the macOS NSBeep alert when typing in editor/terminal after browser use.
- **Project selector mode fix**: New workspaces opened in the same window now inherit `active_mode` from the current workspace instead of from serialized state (which defaults to browser), so the editor stays in editor mode when switching projects.
- **Sidebar state fix**: `BrowserView::new` no longer overwrites the global `BrowserSidebarState` if it already exists, preventing sidebar collapse when a new workspace creates its own BrowserView.
- **Suspended tab improvements**: Tabs now flush cookies and fully close the browser on suspend, recreating on resume/reload for proper resource cleanup.

## Test plan

- [ ] Browser → type in webpage → Cmd+E → type in editor → no macOS alert sound
- [ ] Browser → type → Cmd+T → type in terminal → no alert sound
- [ ] Editor → project selector → pick project → stays in editor mode
- [ ] Browser → open sidebar → project selector → pick project → sidebar stays open
- [ ] Editor → Cmd+B → click text field in browser → type → CEF receives input normally

Release Notes:

- Fixed focus getting stuck in browser when switching to editor or terminal mode
- Fixed project selector switching to browser mode instead of staying in current mode
- Fixed sidebar closing when switching projects

🤖 Generated with [Claude Code](https://claude.com/claude-code)