### PR TITLE
Fix focus management, sidebar state, and browser input

### DIFF
--- a/crates/browser/src/browser_view/input.rs
+++ b/crates/browser/src/browser_view/input.rs
@@ -65,9 +65,14 @@ impl BrowserView {
             let tab = tab.clone();
 
             log::trace!(
-                "[browser::view] handle_key_down: key={:?} native_key_code={:?}",
+                "[browser::view] handle_key_down: key={:?} native_key_code={:?} modifiers=[{}{}{}{}{}]",
                 keystroke.key,
                 keystroke.native_key_code,
+                if keystroke.modifiers.platform { "cmd " } else { "" },
+                if keystroke.modifiers.control { "ctrl " } else { "" },
+                if keystroke.modifiers.alt { "alt " } else { "" },
+                if keystroke.modifiers.shift { "shift " } else { "" },
+                if keystroke.modifiers.function { "fn " } else { "" },
             );
 
             cx.defer(move |cx| {

--- a/crates/browser/src/display_handler.rs
+++ b/crates/browser/src/display_handler.rs
@@ -60,6 +60,20 @@ wrap_display_handler! {
             let _ = self.handler.sender.send(BrowserEvent::LoadingProgress(progress));
         }
 
+        fn on_fullscreen_mode_change(
+            &self,
+            _browser: Option<&mut Browser>,
+            fullscreen: ::std::os::raw::c_int,
+        ) {
+            // Implementing this callback prevents CEF from triggering native
+            // window fullscreen when a website calls requestFullscreen().
+            // The web content still renders fullscreen within the browser view.
+            log::trace!(
+                "[browser::display] on_fullscreen_mode_change: fullscreen={}",
+                fullscreen != 0,
+            );
+        }
+
         fn on_favicon_urlchange(
             &self,
             _browser: Option<&mut Browser>,

--- a/crates/browser/src/tab.rs
+++ b/crates/browser/src/tab.rs
@@ -475,6 +475,14 @@ impl BrowserTab {
         self.with_focused_frame(|frame| frame.del());
     }
 
+    pub fn execute_javascript(&self, code: &str) {
+        self.with_focused_frame(|frame| {
+            let code = cef::CefString::from(code);
+            let url = cef::CefString::from("");
+            frame.execute_java_script(Some(&code), Some(&url), 0);
+        });
+    }
+
     pub fn open_devtools(&self) {
         self.with_host(|host| {
             let window_info = cef::WindowInfo::default();


### PR DESCRIPTION
## Summary

- Fix CEF focus retention, project selector mode switching, and sidebar panel state persistence
- Refactor browser keyboard input to use native keycodes from GPUI, eliminating string-based key name reconstruction
- Fix CEF fullscreen hijacking when websites call `requestFullscreen()` by implementing `on_fullscreen_mode_change` callback
- Add JavaScript injection for Cmd+Backspace/Delete line editing commands that macOS Cocoa text system normally handles

## Test plan

- [ ] Verify typing 'f' in browser text fields does not trigger app fullscreen
- [ ] Verify Cmd+Backspace deletes to beginning of line in browser text fields
- [ ] Verify Cmd+Delete deletes to end of line in browser text fields
- [ ] Verify sidebar panel state persists across project switches
- [ ] Verify keyboard input works correctly across different websites

Release Notes:

- Fixed CEF fullscreen hijacking when websites use requestFullscreen()
- Fixed Cmd+Backspace and Cmd+Delete line editing in browser text fields
- Improved browser keyboard input reliability with native keycode passthrough

🤖 Generated with [Claude Code](https://claude.com/claude-code)