### PR TITLE
Demote browser debug logs from info to trace

### DIFF
--- a/crates/browser/src/browser_view/tabs.rs
+++ b/crates/browser/src/browser_view/tabs.rs
@@ -23,7 +23,7 @@ impl BrowserView {
     }
 
     pub fn open_url(&mut self, url: &str, cx: &mut Context<Self>) {
-        log::info!(
+        log::trace!(
             "[default-browser] BrowserView::open_url called with: {}, message_pump_started: {}, last_viewport: {:?}",
             url,
             self.message_pump_started,
@@ -195,7 +195,7 @@ impl BrowserView {
             let is_new_tab_page = new_tab.read(cx).is_new_tab_page();
             let has_browser = new_tab.read(cx).has_browser();
             let url = new_tab.read(cx).url().to_string();
-            log::info!(
+            log::trace!(
                 "[browser::tabs] switch_to_tab: index={}, url={}, new_tab_page={}, browser={}, suspended={}",
                 index, url, is_new_tab_page, has_browser, is_suspended,
             );
@@ -243,7 +243,7 @@ impl BrowserView {
                             tab.set_scale_factor(scale_factor);
                             tab.set_size(width, height);
                             let url = tab.url().to_string();
-                            log::info!("[browser::tabs] creating browser for tab: {}", url);
+                            log::trace!("[browser::tabs] creating browser for tab: {}", url);
                             if let Err(e) = tab.create_browser(&url) {
                                 log::error!(
                                     "[browser::tabs] Failed to create browser on tab switch: {}",
@@ -424,7 +424,7 @@ impl BrowserView {
             return;
         };
 
-        log::info!(
+        log::trace!(
             "[browser::tabs] close_pinned_tab: url={}, index={}",
             tab.read(cx).url(),
             self.active_tab_index,

--- a/crates/browser/src/tab.rs
+++ b/crates/browser/src/tab.rs
@@ -40,7 +40,7 @@ pub(crate) fn close_all_browsers() -> usize {
     let handles = BROWSER_HANDLES.lock().take().unwrap_or_default();
     let count = handles.len();
     if count > 0 {
-        log::info!(
+        log::trace!(
             "[browser::tab] close_all_browsers: closing {} browser(s)",
             count,
         );
@@ -50,14 +50,14 @@ pub(crate) fn close_all_browsers() -> usize {
         match browser.host() {
             Some(host) => {
                 let ready_to_close = host.is_ready_to_be_closed();
-                log::info!(
+                log::trace!(
                     "[browser::tab] close_all_browsers: id={} is_valid={} ready_to_close={}, requesting close",
                     id, is_valid, ready_to_close,
                 );
                 host.close_browser(1);
             }
             None => {
-                log::info!(
+                log::trace!(
                     "[browser::tab] close_all_browsers: id={} is_valid={} no host",
                     id, is_valid,
                 );
@@ -235,7 +235,7 @@ impl BrowserTab {
 
     pub fn create_browser(&mut self, initial_url: &str) -> Result<()> {
         if self.browser_id.is_some() {
-            log::info!(
+            log::trace!(
                 "[browser::tab] create_browser: SKIPPED (already has browser), url={}",
                 initial_url,
             );
@@ -274,7 +274,7 @@ impl BrowserTab {
             if let Some(context) = host.request_context() {
                 let is_global = context.is_global() != 0;
                 let has_cookie_manager = context.cookie_manager(None).is_some();
-                log::info!(
+                log::trace!(
                     "[browser::tab] Created browser id={} url={} | context: is_global={}, has_cookie_manager={}",
                     browser_id, initial_url, is_global, has_cookie_manager,
                 );
@@ -353,7 +353,7 @@ impl BrowserTab {
             })
             .unwrap_or(false);
 
-        log::info!(
+        log::trace!(
             "[browser::tab] SUSPEND: browser_id={:?}, url={}, handle_in_registry={}",
             browser_id,
             self.url,
@@ -396,7 +396,7 @@ impl BrowserTab {
             })
             .flatten();
 
-        log::info!(
+        log::trace!(
             "[browser::tab] RESUME: browser_id={:?}, url={}, handle_in_registry={}, context={:?}",
             browser_id,
             url,
@@ -423,7 +423,7 @@ impl BrowserTab {
         if self.with_browser(|browser| browser.reload()).is_some() {
             self.is_loading = true;
         } else {
-            log::info!(
+            log::trace!(
                 "[browser] reload called but no browser exists, url={}",
                 self.url,
             );
@@ -674,7 +674,7 @@ impl BrowserTab {
                 let is_valid = browser.is_valid();
                 if let Some(host) = browser.host() {
                     let ready_to_close = host.is_ready_to_be_closed();
-                    log::info!(
+                    log::trace!(
                         "[browser::tab] close_browser: id={} url={} is_valid={} ready_to_close={}",
                         browser_id, self.url, is_valid, ready_to_close,
                     );
@@ -720,12 +720,12 @@ impl Drop for BrowserTab {
             // remove returns None and we skip all CEF API calls.
             let browser = BROWSER_HANDLES.lock().as_mut().and_then(|m| m.remove(&browser_id));
             if let Some(browser) = browser {
-                log::info!(
+                log::trace!(
                     "[browser::tab] Drop: id={} url={} is_valid={}",
                     browser_id, self.url, browser.is_valid(),
                 );
                 if let Some(host) = browser.host() {
-                    log::info!(
+                    log::trace!(
                         "[browser::tab] Drop: id={} ready_to_close={}, calling close_browser(1)",
                         browser_id, host.is_ready_to_be_closed(),
                     );


### PR DESCRIPTION
## Summary

- Downgrade `log::info!` to `log::trace!` in `tab.rs` and `browser_view/tabs.rs` for browser lifecycle, suspend/resume, and tab switching logs that were left at info level from debugging

## Test plan

- [ ] Verify no info-level browser logs spam the console during normal browsing

Release Notes:

- N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)