### PR TITLE
Fix browser click-and-drag text selection

### DIFF
--- a/crates/browser/src/input.rs
+++ b/crates/browser/src/input.rs
@@ -15,6 +15,9 @@ use gpui::{
 const EVENTFLAG_SHIFT_DOWN: u32 = 1 << 1;
 const EVENTFLAG_CONTROL_DOWN: u32 = 1 << 2;
 const EVENTFLAG_ALT_DOWN: u32 = 1 << 3;
+const EVENTFLAG_LEFT_MOUSE_BUTTON: u32 = 1 << 4;
+const EVENTFLAG_MIDDLE_MOUSE_BUTTON: u32 = 1 << 5;
+const EVENTFLAG_RIGHT_MOUSE_BUTTON: u32 = 1 << 6;
 const EVENTFLAG_COMMAND_DOWN: u32 = 1 << 7;
 
 pub fn handle_mouse_down(browser: &BrowserTab, event: &MouseDownEvent, offset: Point<Pixels>) {
@@ -42,7 +45,8 @@ pub fn handle_mouse_move(browser: &BrowserTab, event: &MouseMoveEvent, offset: P
     let position = event.position - offset;
     let x = f32::from(position.x) as i32;
     let y = f32::from(position.y) as i32;
-    let modifiers = convert_modifiers(&event.modifiers);
+    let mut modifiers = convert_modifiers(&event.modifiers);
+    modifiers |= pressed_button_flags(event.pressed_button);
 
     browser.send_mouse_move(x, y, false, modifiers);
 }
@@ -177,6 +181,15 @@ pub fn handle_key_up_deferred(browser: &BrowserTab, keystroke: &Keystroke) {
     );
 
     browser.send_key_event(&cef_event);
+}
+
+fn pressed_button_flags(pressed_button: Option<MouseButton>) -> u32 {
+    match pressed_button {
+        Some(MouseButton::Left) | Some(MouseButton::Navigate(_)) => EVENTFLAG_LEFT_MOUSE_BUTTON,
+        Some(MouseButton::Middle) => EVENTFLAG_MIDDLE_MOUSE_BUTTON,
+        Some(MouseButton::Right) => EVENTFLAG_RIGHT_MOUSE_BUTTON,
+        None => 0,
+    }
 }
 
 fn convert_mouse_button(button: MouseButton) -> MouseButtonType {


### PR DESCRIPTION
## Summary

- Forward pressed mouse button state from GPUI's `MouseMoveEvent` to CEF via event flags, enabling click-and-drag text selection in the browser view

Mouse move events were only sending keyboard modifiers (shift/ctrl/alt/cmd) to CEF but not the pressed button state. CEF needs `EVENTFLAG_LEFT_MOUSE_BUTTON` in the modifiers during mouse move to know the user is dragging, otherwise it treats it as plain hover movement and never extends the selection.

Double/triple-click selection was unaffected since those go through `send_mouse_click` with `click_count`.

## Test plan

- [ ] Open a browser tab, click and drag over text — should now show blue selection highlight
- [ ] Verify double-click (word) and triple-click (paragraph) selection still work
- [ ] Verify Shift+click to extend selection works
- [ ] Verify right-click and middle-click drag behavior is unaffected

Release Notes:

- Fixed click-and-drag text selection in the browser view

🤖 Generated with [Claude Code](https://claude.com/claude-code)