### PR TITLE
Update branding and documentation from Zed to Glass

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,3 +1,3 @@
 # Code of Conduct
 
-The Code of Conduct for this repository can be found online at [zed.dev/code-of-conduct](https://zed.dev/code-of-conduct).
+Be respectful, constructive, and professional. We do not tolerate harassment or abusive behavior of any kind.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,67 +1,37 @@
-# Contributing to Zed
+# Contributing to Glass
 
-Thank you for helping us make Zed better!
+Thank you for helping us make Glass better!
 
-All activity in Zed forums is subject to our [Code of
-Conduct](https://zed.dev/code-of-conduct). Additionally, contributors must sign
-our [Contributor License Agreement](https://zed.dev/cla) before their
-contributions can be merged.
+> Glass is a fork of [Zed](https://github.com/zed-industries/zed). When contributing, please keep in mind that some crates and patterns originate from upstream Zed.
 
 ## Contribution ideas
 
-Zed is a large project with a number of priorities. We spend most of
-our time working on what we believe the product needs, but we also love working
-with the community to improve the product in ways we haven't thought of (or had time to get to yet!)
-
-In particular we love PRs that are:
+Glass is in active development. We welcome PRs that are:
 
 - Fixing or extending the docs.
 - Fixing bugs.
-- Small enhancements to existing features to make them work for more people (making things work on more platforms/modes/whatever).
+- Small enhancements to existing features to make them work for more people.
 - Small extra features, like keybindings or actions you miss from other editors or extensions.
-- Part of a Community Program like [Let's Git Together](https://github.com/zed-industries/zed/issues/41541).
 
-If you're looking for concrete ideas:
-
-- [Triaged bugs with confirmed steps to reproduce](https://github.com/zed-industries/zed/issues?q=is%3Aissue%20state%3Aopen%20type%3ABug%20label%3Astate%3Areproducible).
-- [Area labels](https://github.com/zed-industries/zed/labels?q=area%3A*) to browse bugs in a specific part of the product you care about (after clicking on an area label, add type:Bug to the search).
+If you're looking for concrete ideas, check the [issues](https://github.com/Glass-HQ/Glass/issues) page.
 
 ## Sending changes
-
-The Zed culture values working code and synchronous conversations over long
-discussion threads.
 
 The best way to get us to take a look at a proposed change is to send a pull
 request. We will get back to you (though this sometimes takes longer than we'd
 like, sorry).
 
-Although we will take a look, we tend to only merge about half the PRs that are
-submitted. If you'd like your PR to have the best chance of being merged:
-
 - Make sure the change is **desired**: we're always happy to accept bugfixes,
   but features should be confirmed with us first if you aim to avoid wasted
-  effort. If there isn't already a GitHub issue for your feature with staff
+  effort. If there isn't already a GitHub issue for your feature with
   confirmation that we want it, start with a GitHub discussion rather than a PR.
 - Include a clear description of **what you're solving**, and why it's important.
-- Include **tests**. For UI changes, consider updating visual regression tests (see [Building Zed for macOS](./docs/src/development/macos.md#visual-regression-tests)).
+- Include **tests**. For UI changes, consider updating visual regression tests (see [Building Glass for macOS](./docs/src/development/macos.md#visual-regression-tests)).
 - If it changes the UI, attach **screenshots** or screen recordings.
 - Make the PR about **one thing only**, e.g. if it's a bugfix, don't add two
   features and a refactoring on top of that.
 - Keep AI assistance under your judgement and responsibility: it's unlikely
   we'll merge a vibe-coded PR that the author doesn't understand.
-
-The internal advice for reviewers is as follows:
-
-- If the fix/feature is obviously great, and the code is great. Hit merge.
-- If the fix/feature is obviously great, and the code is nearly great. Send PR comments, or offer to pair to get things perfect.
-- If the fix/feature is not obviously great, or the code needs rewriting from scratch. Close the PR with a thank you and some explanation.
-
-If you need more feedback from us: the best way is to be responsive to
-Github comments, or to offer up time to pair with us.
-
-If you need help deciding how to fix a bug, or finish implementing a feature
-that we've agreed we want, please open a PR early so we can discuss how to make
-the change with code in hand.
 
 ### UI/UX checklist
 
@@ -83,10 +53,6 @@ When your changes affect UI, consult this checklist:
 - Does resizing panes or windows keep the UI usable and attractive?
 - Do dialogs or modals stay centered and within viewport bounds?
 
-**Platform Consistency**
-- Is the feature fully usable on Windows, Linux, and Mac?
-- Does it respect system-level settings (fonts, scaling, input methods)?
-
 **Performance**
 - All user interactions must have instant feedback.
     - If the user requests something slow (e.g. an LLM generation) there should be some indication of the work in progress.
@@ -94,60 +60,47 @@ When your changes affect UI, consult this checklist:
 - Frames must take no more than 8ms (120fps)
 
 **Consistency**
-- Does it match Zed’s design language (spacing, typography, icons)?
-- Are terminology, labels, and tone consistent with the rest of Zed?
+- Does it match Glass's design language (spacing, typography, icons)?
+- Are terminology, labels, and tone consistent with the rest of Glass?
 - Are interactions consistent (e.g., how tabs close, how modals dismiss, how errors show)?
 
 **Internationalization & Text**
 - Are strings concise, clear, and unambiguous?
-- Do we avoid internal Zed jargon that only insiders would know?
 
 **User Paths & Edge Cases**
 - What does the happy path look like?
 - What does the unhappy path look like? (errors, rejections, invalid states)
-- How does it work in offline vs. online states?
-- How does it work in unauthenticated vs. authenticated states?
 - How does it behave if data is missing, corrupted, or delayed?
-- Are error messages actionable and consistent with Zed’s voice?
+- Are error messages actionable and consistent with Glass's voice?
 
 **Discoverability & Learning**
 - Can a first-time user figure it out without docs?
 - Is there an intuitive way to undo/redo actions?
 - Are power features discoverable but not intrusive?
-- Is there a path from beginner → expert usage (progressive disclosure)?
-
+- Is there a path from beginner to expert usage (progressive disclosure)?
 
 ## Things we will (probably) not merge
 
 Although there are few hard and fast rules, typically we don't merge:
 
-- Anything that can be provided by an extension. For example a new language, or theme. For adding themes or support for a new language to Zed, check out our [docs on developing extensions](https://zed.dev/docs/extensions/developing-extensions).
-- New file icons. Zed's default icon theme consists of icons that are hand-designed to fit together in a cohesive manner, please don't submit PRs with off-the-shelf SVGs.
+- Anything that can be provided by an extension. For adding themes or support for a new language, check out the [docs on developing extensions](https://zed.dev/docs/extensions/developing-extensions).
 - Features where (in our subjective opinion) the extra complexity isn't worth it for the number of people who will benefit.
 - Giant refactorings.
 - Non-trivial changes with no tests.
-- Stylistic code changes that do not alter any app logic. Reducing allocations, removing `.unwrap()`s, fixing typos is great; making code "more readable" — maybe not so much.
+- Stylistic code changes that do not alter any app logic.
 - Anything that seems AI-generated without understanding the output.
 
-## Bird's-eye view of Zed
+## Bird's-eye view of Glass
 
-We suggest you keep the [Zed glossary](docs/src/development/glossary.md) at your side when starting out. It lists and explains some of the structures and terms you will see throughout the codebase.
+Glass is built on top of Zed's crate architecture. Here are the crates you're most likely to interact with:
 
-Zed is made up of several smaller crates - let's go over those you're most likely to interact with:
-
-- [`gpui`](/crates/gpui) is a GPU-accelerated UI framework which provides all of the building blocks for Zed. **We recommend familiarizing yourself with the root level GPUI documentation.**
-- [`editor`](/crates/editor) contains the core `Editor` type that drives both the code editor and all various input fields within Zed. It also handles a display layer for LSP features such as Inlay Hints or code completions.
-- [`project`](/crates/project) manages files and navigation within the filetree. It is also Zed's side of communication with LSP.
+- [`gpui`](/crates/gpui) is a GPU-accelerated UI framework which provides all of the building blocks for Glass. We maintain a [standalone fork](https://github.com/Obsydian-HQ/gpui) with native iOS/macOS component extensions. **We recommend familiarizing yourself with the root level GPUI documentation.**
+- [`editor`](/crates/editor) contains the core `Editor` type that drives both the code editor and all various input fields. It also handles a display layer for LSP features such as Inlay Hints or code completions.
+- [`project`](/crates/project) manages files and navigation within the filetree. It is also the app's side of communication with LSP.
 - [`workspace`](/crates/workspace) handles local state serialization and groups projects together.
-- [`lsp`](/crates/lsp) handles communication with external LSP server.
-- [`language`](/crates/language) drives `editor`'s understanding of language - from providing a list of symbols to the syntax map.
-- [`collab`](/crates/collab) is the collaboration server itself, driving the collaboration features such as project sharing.
-- [`rpc`](/crates/rpc) defines messages to be exchanged with collaboration server.
-- [`theme`](/crates/theme) defines the theme system and provides a default theme.
-- [`ui`](/crates/ui) is a collection of UI components and common patterns used throughout Zed.
-- [`cli`](/crates/cli) is the CLI crate which invokes the Zed binary.
-- [`zed`](/crates/zed) is where all things come together, and the `main` entry point for Zed.
-
-## Packaging Zed
-
-Check our [notes for packaging Zed](https://zed.dev/docs/development/linux#notes-for-packaging-zed).
+- [`browser`](/crates/browser) provides the integrated browser powered by CEF.
+- [`lsp`](/crates/lsp) handles communication with external LSP servers.
+- [`language`](/crates/language) drives `editor`'s understanding of language — from providing a list of symbols to the syntax map.
+- [`theme`](/crates/theme) defines the theme system and provides default themes.
+- [`ui`](/crates/ui) is a collection of UI components and common patterns used throughout Glass.
+- [`zed`](/crates/zed) is where all things come together, and the `main` entry point for Glass.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2863,6 +2863,7 @@ dependencies = [
 [[package]]
 name = "collections"
 version = "0.1.0"
+source = "git+https://github.com/Obsydian-HQ/gpui.git#6f39efa07cc54463ab8fb8662456335d62360e25"
 dependencies = [
  "indexmap",
  "rustc-hash 2.1.1",
@@ -4160,6 +4161,7 @@ dependencies = [
 [[package]]
 name = "derive_refineable"
 version = "0.1.0"
+source = "git+https://github.com/Obsydian-HQ/gpui.git#6f39efa07cc54463ab8fb8662456335d62360e25"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6677,6 +6679,7 @@ dependencies = [
 [[package]]
 name = "gpui"
 version = "0.2.2"
+source = "git+https://github.com/Obsydian-HQ/gpui.git#6f39efa07cc54463ab8fb8662456335d62360e25"
 dependencies = [
  "anyhow",
  "as-raw-xcb-connection",
@@ -6776,6 +6779,7 @@ dependencies = [
 [[package]]
 name = "gpui_macros"
 version = "0.1.0"
+source = "git+https://github.com/Obsydian-HQ/gpui.git#6f39efa07cc54463ab8fb8662456335d62360e25"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -6786,6 +6790,7 @@ dependencies = [
 [[package]]
 name = "gpui_tokio"
 version = "0.1.0"
+source = "git+https://github.com/Obsydian-HQ/gpui.git#6f39efa07cc54463ab8fb8662456335d62360e25"
 dependencies = [
  "anyhow",
  "gpui",
@@ -7169,6 +7174,7 @@ dependencies = [
 [[package]]
 name = "http_client"
 version = "0.1.0"
+source = "git+https://github.com/Obsydian-HQ/gpui.git#6f39efa07cc54463ab8fb8662456335d62360e25"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -7193,6 +7199,7 @@ dependencies = [
 [[package]]
 name = "http_client_tls"
 version = "0.1.0"
+source = "git+https://github.com/Obsydian-HQ/gpui.git#6f39efa07cc54463ab8fb8662456335d62360e25"
 dependencies = [
  "rustls 0.23.33",
  "rustls-platform-verifier",
@@ -9014,6 +9021,7 @@ dependencies = [
 [[package]]
 name = "media"
 version = "0.1.0"
+source = "git+https://github.com/Obsydian-HQ/gpui.git#6f39efa07cc54463ab8fb8662456335d62360e25"
 dependencies = [
  "anyhow",
  "bindgen",
@@ -12367,6 +12375,7 @@ dependencies = [
 [[package]]
 name = "refineable"
 version = "0.1.0"
+source = "git+https://github.com/Obsydian-HQ/gpui.git#6f39efa07cc54463ab8fb8662456335d62360e25"
 dependencies = [
  "derive_refineable",
 ]
@@ -13214,6 +13223,7 @@ dependencies = [
 [[package]]
 name = "scheduler"
 version = "0.1.0"
+source = "git+https://github.com/Obsydian-HQ/gpui.git#6f39efa07cc54463ab8fb8662456335d62360e25"
 dependencies = [
  "async-task",
  "backtrace",
@@ -14342,6 +14352,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 [[package]]
 name = "sum_tree"
 version = "0.1.0"
+source = "git+https://github.com/Obsydian-HQ/gpui.git#6f39efa07cc54463ab8fb8662456335d62360e25"
 dependencies = [
  "arrayvec",
  "log",
@@ -16491,6 +16502,7 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 [[package]]
 name = "util"
 version = "0.1.0"
+source = "git+https://github.com/Obsydian-HQ/gpui.git#6f39efa07cc54463ab8fb8662456335d62360e25"
 dependencies = [
  "anyhow",
  "async-fs",

--- a/README.md
+++ b/README.md
@@ -1,31 +1,35 @@
-# Zed
+# Glass
 
-[![Zed](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/zed-industries/zed/main/assets/badge/v0.json)](https://zed.dev)
-[![CI](https://github.com/zed-industries/zed/actions/workflows/run_tests.yml/badge.svg)](https://github.com/zed-industries/zed/actions/workflows/run_tests.yml)
+Glass is a browser, code editor, and terminal in one app. Instead of switching between separate applications, everything lives in the same environment. Anyone can use the browser — developers also get an editor, terminal, and native platform tooling alongside it.
 
-Welcome to Zed, a high-performance, multiplayer code editor from the creators of [Atom](https://github.com/atom/atom) and [Tree-sitter](https://github.com/tree-sitter/tree-sitter).
+> **Glass is a fork of [Zed](https://github.com/zed-industries/zed).** We actively sync with upstream every week. Glass would not be possible without the incredible work the Zed team continues to do.
+
+Glass is in **active development**. The focus right now is macOS, with Windows, Linux, iOS, and Android planned.
 
 ---
 
-### Installation
+### What is Glass?
 
-On macOS, Linux, and Windows you can [download Zed directly](https://zed.dev/download) or install Zed via your local package manager ([macOS](https://zed.dev/docs/installation#macos)/[Linux](https://zed.dev/docs/linux#installing-via-a-package-manager)/[Windows](https://zed.dev/docs/windows#package-managers)).
+- **Browser** — A full browser. Browse, stream, work — you never have to touch the editor if you don't want to.
+- **Code editor** — Inherited from Zed, with significant UI changes and native macOS components.
+- **Terminal** — Built into the same environment.
+- **Native platform tooling** — Build, run, and test iOS and macOS apps without opening Xcode. Manage App Store Connect without opening the web app.
 
-Other platforms are not yet available:
+For developers, everything is connected. Build a web app and test it in the same browser. Build a native app and run it without leaving Glass. Deep integration between these workspaces is the long-term vision.
 
-- Web ([tracking issue](https://github.com/zed-industries/zed/issues/5396))
+### GPUI
 
-### Developing Zed
+Zed's UI framework, [GPUI](https://github.com/zed-industries/zed/tree/main/crates/gpui), lives in the same repository as Zed. We separated it into its own standalone repository at **[Obsydian-HQ/gpui](https://github.com/Obsydian-HQ/gpui)** and extended it with native iOS and macOS components, making it a framework that multiple apps can build on. We are also bringing iOS support to GPUI so that apps built with it can run everywhere.
 
-- [Building Zed for macOS](./docs/src/development/macos.md)
-- [Building Zed for Linux](./docs/src/development/linux.md)
-- [Building Zed for Windows](./docs/src/development/windows.md)
+---
+
+### Building Glass
+
+- [Building for macOS](./docs/src/development/macos.md)
 
 ### Contributing
 
-See [CONTRIBUTING.md](./CONTRIBUTING.md) for ways you can contribute to Zed.
-
-Also... we're hiring! Check out our [jobs](https://zed.dev/jobs) page for open roles.
+See [CONTRIBUTING.md](./CONTRIBUTING.md) for ways you can contribute to Glass.
 
 ### Licensing
 
@@ -37,10 +41,6 @@ We use [`cargo-about`](https://github.com/EmbarkStudios/cargo-about) to automati
 - Is the error `failed to satisfy license requirements` for a dependency? If so, first determine what license the project has and whether this system is sufficient to comply with this license's requirements. If you're unsure, ask a lawyer. Once you've verified that this system is acceptable add the license's SPDX identifier to the `accepted` array in `script/licenses/zed-licenses.toml`.
 - Is `cargo-about` unable to find the license for a dependency? If so, add a clarification field at the end of `script/licenses/zed-licenses.toml`, as specified in the [cargo-about book](https://embarkstudios.github.io/cargo-about/cli/generate/config.html#crate-configuration).
 
-## Sponsorship
+### Acknowledgments
 
-Zed is developed by **Zed Industries, Inc.**, a for-profit company.
-
-If you’d like to financially support the project, you can do so via GitHub Sponsors.
-Sponsorships go directly to Zed Industries and are used as general company revenue.
-There are no perks or entitlements associated with sponsorship.
+Glass is built on top of [Zed](https://github.com/zed-industries/zed), created by **Zed Industries, Inc.** — the team behind [Atom](https://github.com/atom/atom) and [Tree-sitter](https://github.com/tree-sitter/tree-sitter). Their work on the editor, GPUI, and the broader ecosystem made Glass possible.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,8 +1,8 @@
-# Zed Docs
+# Glass Docs
 
-Welcome to Zed's documentation.
+Welcome to Glass's documentation.
 
-This is built on push to `main` and published automatically to [https://zed.dev/docs](https://zed.dev/docs).
+> These docs are inherited from upstream Zed. The documentation infrastructure and content will be updated in the future.
 
 To preview the docs locally you will need to install [mdBook](https://rust-lang.github.io/mdBook/) (`cargo install mdbook@0.4.40`) and then run:
 

--- a/docs/book.toml
+++ b/docs/book.toml
@@ -1,9 +1,9 @@
 [book]
-authors = ["The Zed Team"]
+authors = ["Glass HQ"]
 language = "en"
 multilingual = false
 src = "src"
-title = "Zed"
+title = "Glass"
 site-url = "/docs/"
 
 [build]
@@ -19,8 +19,8 @@ extra-watch-dirs = ["../crates/docs_preprocessor"]
 command = "cargo run -p docs_preprocessor -- postprocess"
 # Set here instead of above as we only use it replace the `#description#` we set in the template
 # when no front-matter is provided value
-default-description = "Learn how to use and customize Zed, the fast, collaborative code editor. Official docs on features, configuration, AI tools, and workflows."
-default-title = "Zed Code Editor Documentation"
+default-description = "Learn how to use and customize Glass — a browser, code editor, and terminal in one app. Docs on features, configuration, and workflows."
+default-title = "Glass Documentation"
 no-section-label = true
 preferred-dark-theme = "dark"
 additional-css = ["theme/page-toc.css", "theme/plugins.css", "theme/highlight.css"]

--- a/extensions/README.md
+++ b/extensions/README.md
@@ -1,12 +1,14 @@
-# Zed Extensions
+# Extensions
 
-This directory contains extensions for Zed that are largely maintained by the Zed team. They currently live in the Zed repository for ease of maintenance.
+> This extension system is inherited from upstream [Zed](https://github.com/zed-industries/zed) and will change in the future.
+
+This directory contains extensions that are largely maintained by the Glass team. They currently live in the Glass repository for ease of maintenance.
 
 If you are looking for the Zed extension registry, see the [`zed-industries/extensions`](https://github.com/zed-industries/extensions) repo.
 
 ## Structure
 
-Currently, Zed includes support for a number of languages without requiring installing an extension. Those languages can be found under [`crates/languages/src`](https://github.com/zed-industries/zed/tree/main/crates/languages/src).
+Glass includes support for a number of languages without requiring installing an extension. Those languages can be found under [`crates/languages/src`](https://github.com/zed-industries/zed/tree/main/crates/languages/src).
 
 Support for all other languages is done via extensions. This directory ([extensions/](https://github.com/zed-industries/zed/tree/main/extensions/)) contains a number of officially maintained extensions. These extensions use the same [zed_extension_api](https://docs.rs/zed_extension_api/latest/zed_extension_api/) available to all [Zed Extensions](https://zed.dev/extensions) for providing [language servers](https://zed.dev/docs/extensions/languages#language-servers), [tree-sitter grammars](https://zed.dev/docs/extensions/languages#grammar) and [tree-sitter queries](https://zed.dev/docs/extensions/languages#tree-sitter-queries).
 
@@ -15,10 +17,6 @@ Support for all other languages is done via extensions. This directory ([extensi
 See the docs for [Developing an Extension Locally](https://zed.dev/docs/extensions/developing-extensions#developing-an-extension-locally) for how to work with one of these extensions.
 
 ## Updating
-
-> [!NOTE]
-> This update process is usually handled by Zed staff.
-> Community contributors should just submit a PR (step 1) and we'll take it from there.
 
 The process for updating an extension in this directory has three parts.
 


### PR DESCRIPTION
## Summary

- Rewrite README to describe Glass as a browser, editor, and terminal in one app
- Update CONTRIBUTING.md with Glass branding, remove Zed-specific links (CLA, community programs), add `browser` crate, remove `collab`/`rpc`/`cli` crates
- Replace CODE_OF_CONDUCT.md with standalone statement instead of linking to zed.dev
- Update docs/README.md and docs/book.toml metadata for Glass
- Update extensions/README.md with note that extension system is inherited from Zed
- All files clearly attribute Zed as the upstream fork and note active weekly syncing

## Test plan

- [ ] Verify README renders correctly on GitHub
- [ ] Verify docs build with `mdbook serve docs`
- [ ] Verify no broken links in markdown files

Release Notes:

- N/A