### PR TITLE
Add explicit licensing information to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,12 @@ See [CONTRIBUTING.md](./CONTRIBUTING.md) for ways you can contribute to Glass.
 
 ### Licensing
 
+Glass is licensed under the [GNU General Public License v3.0 or later](./LICENSE-GPL). This is the same license used by [Zed](https://github.com/zed-industries/zed), the project Glass is forked from.
+
+A small number of utility crates are licensed under [Apache License 2.0](./LICENSE-APACHE). See individual crate `Cargo.toml` files for details.
+
+#### Third-party dependency compliance
+
 License information for third party dependencies must be correctly provided for CI to pass.
 
 We use [`cargo-about`](https://github.com/EmbarkStudios/cargo-about) to automatically comply with open source licenses. If CI is failing, check the following:


### PR DESCRIPTION
## Summary

- Add clear statement that Glass is licensed under GPL-3.0-or-later (same as upstream Zed)
- Note that a small number of utility crates use Apache-2.0
- Move existing third-party dependency compliance info under a subheading

Previously the Licensing section only discussed CI compliance for third-party dependencies. It did not state what Glass itself is licensed under, which is a compliance gap for a public fork shipping GPL binaries.

Release Notes:

- N/A