### PR TITLE
Adjust remote_server for GPUI web sync

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -797,6 +797,7 @@ calloop = { git = "https://github.com/zed-industries/calloop" }
 # gpui_macros = { path = "../../Obsydian-HQ/gpui/crates/gpui_macros" }
 # gpui_platform = { path = "../../Obsydian-HQ/gpui/crates/gpui_platform" }
 # gpui_tokio = { path = "../../Obsydian-HQ/gpui/crates/gpui_tokio" }
+# gpui_web = { path = "../../Obsydian-HQ/gpui/crates/gpui_web" }
 # http_client = { path = "../../Obsydian-HQ/gpui/crates/http_client" }
 # http_client_tls = { path = "../../Obsydian-HQ/gpui/crates/http_client_tls" }
 # media = { path = "../../Obsydian-HQ/gpui/crates/media" }

--- a/crates/remote_server/Cargo.toml
+++ b/crates/remote_server/Cargo.toml
@@ -82,6 +82,7 @@ minidumper.workspace = true
 
 [target.'cfg(windows)'.dependencies]
 windows.workspace = true
+gpui = { workspace = true, features = ["windows-manifest"] }
 
 [dev-dependencies]
 action_log.workspace = true


### PR DESCRIPTION
## Summary
- move the `windows-manifest` gpui feature gate to the Windows-only dependency edge in `remote_server`
- add the local split-repo patch hint for `gpui_web` alongside the existing gpui development overrides
- validate Glass against both the published gpui dependency and the local extracted gpui checkout

## Validation
- `cargo check -p remote_server`
- `./script/bundle-mac-cef`
- temporary local gpui patch override plus `./script/bundle-mac-cef`, then reverted

Release Notes:

- N/A