### PR TITLE
Fix remote server release assets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -471,7 +471,7 @@ jobs:
     - run_tests_mac
     - clippy_mac
     - check_scripts
-    runs-on: namespace-profile-mac-large
+    runs-on: macos-15-intel
     env:
       CARGO_INCREMENTAL: 0
       ZED_CLIENT_CHECKSUM_SEED: ${{ secrets.ZED_CLIENT_CHECKSUM_SEED }}

--- a/.github/workflows/release_glass.yml
+++ b/.github/workflows/release_glass.yml
@@ -868,6 +868,17 @@ jobs:
           security default-keychain -s login.keychain || true
           security delete-keychain build.keychain || true
 
+      - name: Package remote server binary
+        run: |
+          REMOTE_SERVER_BIN="target/${{ matrix.target }}/release/remote_server"
+          REMOTE_SERVER_GZ="target/${{ matrix.target }}/release/zed-remote-server-macos-${{ matrix.arch }}.gz"
+          if [ -f "$REMOTE_SERVER_BIN" ]; then
+            gzip -c "$REMOTE_SERVER_BIN" > "$REMOTE_SERVER_GZ"
+            echo "Packaged remote server: $REMOTE_SERVER_GZ ($(du -h "$REMOTE_SERVER_GZ" | cut -f1))"
+          else
+            echo "WARNING: remote_server binary not found at $REMOTE_SERVER_BIN"
+          fi
+
       - name: Upload DMG artifact
         uses: actions/upload-artifact@v4
         with:
@@ -881,6 +892,13 @@ jobs:
           name: Glass-${{ matrix.arch }}-symbols.zip
           path: target/${{ matrix.target }}/release/Glass-${{ matrix.arch }}-symbols.zip
           if-no-files-found: error
+
+      - name: Upload remote server artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: zed-remote-server-macos-${{ matrix.arch }}.gz
+          path: target/${{ matrix.target }}/release/zed-remote-server-macos-${{ matrix.arch }}.gz
+          if-no-files-found: warn
 
   create-release:
     name: Create GitHub Release
@@ -918,8 +936,10 @@ jobs:
           files: |
             artifacts/Glass-aarch64.dmg/Glass-aarch64.dmg
             artifacts/Glass-aarch64-symbols.zip/Glass-aarch64-symbols.zip
+            artifacts/zed-remote-server-macos-aarch64.gz/zed-remote-server-macos-aarch64.gz
             # Intel build disabled - uncomment when re-enabled:
             # artifacts/Glass-x86_64.dmg/Glass-x86_64.dmg
+            # artifacts/zed-remote-server-macos-x86_64.gz/zed-remote-server-macos-x86_64.gz
           body: |
             ## Glass ${{ env.RELEASE_VERSION }}
 

--- a/.github/workflows/release_glass.yml
+++ b/.github/workflows/release_glass.yml
@@ -47,6 +47,11 @@ jobs:
         with:
           clean: false
 
+      - name: Set app version
+        run: |
+          echo "APP_VERSION=${RELEASE_VERSION#v}" >> "$GITHUB_ENV"
+          echo "ZED_APP_VERSION=${RELEASE_VERSION#v}" >> "$GITHUB_ENV"
+
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
         with:
@@ -242,7 +247,7 @@ jobs:
           echo "Generated Glass.icns"
 
           # Generate Info.plist with all bundle metadata and plist extensions merged
-          cat > "$APP_PATH/Contents/Info.plist" << 'PLIST'
+          cat > "$APP_PATH/Contents/Info.plist" << PLIST
           <?xml version="1.0" encoding="UTF-8"?>
           <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
           <plist version="1.0">
@@ -264,9 +269,9 @@ jobs:
               <key>CFBundlePackageType</key>
               <string>APPL</string>
               <key>CFBundleShortVersionString</key>
-              <string>0.0.1</string>
+              <string>$APP_VERSION</string>
               <key>CFBundleVersion</key>
-              <string>0.0.1</string>
+              <string>$APP_VERSION</string>
               <key>LSMinimumSystemVersion</key>
               <string>10.15.7</string>
               <key>NSHighResolutionCapable</key>
@@ -916,6 +921,10 @@ jobs:
         with:
           clean: false
 
+      - name: Set app version
+        run: |
+          echo "ZED_APP_VERSION=${RELEASE_VERSION#v}" >> "$GITHUB_ENV"
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
@@ -948,6 +957,10 @@ jobs:
         uses: actions/checkout@v4
         with:
           clean: false
+
+      - name: Set app version
+        run: |
+          echo "ZED_APP_VERSION=${RELEASE_VERSION#v}" >> "$GITHUB_ENV"
 
       - name: Setup Sentry
         uses: matbour/setup-sentry-cli@v2
@@ -982,6 +995,10 @@ jobs:
         uses: actions/checkout@v4
         with:
           clean: false
+
+      - name: Set app version
+        run: |
+          echo "ZED_APP_VERSION=${RELEASE_VERSION#v}" >> "$GITHUB_ENV"
 
       - name: Setup Sentry
         uses: matbour/setup-sentry-cli@v2
@@ -1024,6 +1041,12 @@ jobs:
         with:
           clean: false
 
+      - name: Set app version
+        shell: pwsh
+        run: |
+          $version = $env:RELEASE_VERSION.TrimStart('v')
+          "ZED_APP_VERSION=$version" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+
       - name: Setup Sentry
         uses: matbour/setup-sentry-cli@v2
         with:
@@ -1059,6 +1082,12 @@ jobs:
         uses: actions/checkout@v4
         with:
           clean: false
+
+      - name: Set app version
+        shell: pwsh
+        run: |
+          $version = $env:RELEASE_VERSION.TrimStart('v')
+          "ZED_APP_VERSION=$version" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
       - name: Setup Sentry
         uses: matbour/setup-sentry-cli@v2

--- a/.github/workflows/release_glass.yml
+++ b/.github/workflows/release_glass.yml
@@ -907,7 +907,7 @@ jobs:
 
   bundle-macos-x86_64-remote-server:
     name: Bundle macOS remote server (x86_64)
-    runs-on: macos-14
+    runs-on: macos-15-intel
     env:
       MACOS_CERTIFICATE: ${{ secrets.MACOS_CERTIFICATE }}
       MACOS_CERTIFICATE_PASSWORD: ${{ secrets.MACOS_CERTIFICATE_PASSWORD }}

--- a/.github/workflows/release_glass.yml
+++ b/.github/workflows/release_glass.yml
@@ -898,11 +898,193 @@ jobs:
         with:
           name: zed-remote-server-macos-${{ matrix.arch }}.gz
           path: target/${{ matrix.target }}/release/zed-remote-server-macos-${{ matrix.arch }}.gz
-          if-no-files-found: warn
+          if-no-files-found: error
+
+  bundle-macos-x86_64-remote-server:
+    name: Bundle macOS remote server (x86_64)
+    runs-on: macos-14
+    env:
+      MACOS_CERTIFICATE: ${{ secrets.MACOS_CERTIFICATE }}
+      MACOS_CERTIFICATE_PASSWORD: ${{ secrets.MACOS_CERTIFICATE_PASSWORD }}
+      APPLE_NOTARIZATION_KEY: ${{ secrets.APPLE_NOTARIZATION_KEY }}
+      APPLE_NOTARIZATION_KEY_ID: ${{ secrets.APPLE_NOTARIZATION_KEY_ID }}
+      APPLE_NOTARIZATION_ISSUER_ID: ${{ secrets.APPLE_NOTARIZATION_ISSUER_ID }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          clean: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Setup Sentry
+        uses: matbour/setup-sentry-cli@v2
+        with:
+          token: ${{ secrets.SENTRY_AUTH_TOKEN }}
+
+      - name: Build macOS remote server bundle
+        run: ./script/bundle-mac x86_64-apple-darwin
+
+      - name: Upload remote server artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: zed-remote-server-macos-x86_64.gz
+          path: target/zed-remote-server-macos-x86_64.gz
+          if-no-files-found: error
+
+  bundle-linux-aarch64-remote-server:
+    name: Bundle Linux remote server (aarch64)
+    runs-on: namespace-profile-8x32-ubuntu-2004-arm-m4
+    env:
+      CC: clang-18
+      CXX: clang++-18
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          clean: false
+
+      - name: Setup Sentry
+        uses: matbour/setup-sentry-cli@v2
+        with:
+          token: ${{ secrets.SENTRY_AUTH_TOKEN }}
+
+      - name: Setup Linux build environment
+        run: ./script/linux
+
+      - name: Download WASI SDK
+        run: ./script/download-wasi-sdk
+
+      - name: Build Linux remote server bundle
+        run: ./script/bundle-linux
+
+      - name: Upload remote server artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: zed-remote-server-linux-aarch64.gz
+          path: target/zed-remote-server-linux-aarch64.gz
+          if-no-files-found: error
+
+  bundle-linux-x86_64-remote-server:
+    name: Bundle Linux remote server (x86_64)
+    runs-on: namespace-profile-32x64-ubuntu-2004
+    env:
+      CC: clang-18
+      CXX: clang++-18
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          clean: false
+
+      - name: Setup Sentry
+        uses: matbour/setup-sentry-cli@v2
+        with:
+          token: ${{ secrets.SENTRY_AUTH_TOKEN }}
+
+      - name: Setup Linux build environment
+        run: ./script/linux
+
+      - name: Download WASI SDK
+        run: ./script/download-wasi-sdk
+
+      - name: Build Linux remote server bundle
+        run: ./script/bundle-linux
+
+      - name: Upload remote server artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: zed-remote-server-linux-x86_64.gz
+          path: target/zed-remote-server-linux-x86_64.gz
+          if-no-files-found: error
+
+  bundle-windows-aarch64-remote-server:
+    name: Bundle Windows remote server (aarch64)
+    runs-on: self-32vcpu-windows-2022
+    env:
+      AZURE_TENANT_ID: ${{ secrets.AZURE_SIGNING_TENANT_ID }}
+      AZURE_CLIENT_ID: ${{ secrets.AZURE_SIGNING_CLIENT_ID }}
+      AZURE_CLIENT_SECRET: ${{ secrets.AZURE_SIGNING_CLIENT_SECRET }}
+      ACCOUNT_NAME: ${{ vars.AZURE_SIGNING_ACCOUNT_NAME }}
+      CERT_PROFILE_NAME: ${{ vars.AZURE_SIGNING_CERT_PROFILE_NAME }}
+      ENDPOINT: ${{ vars.AZURE_SIGNING_ENDPOINT }}
+      FILE_DIGEST: SHA256
+      TIMESTAMP_DIGEST: SHA256
+      TIMESTAMP_SERVER: http://timestamp.acs.microsoft.com
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          clean: false
+
+      - name: Setup Sentry
+        uses: matbour/setup-sentry-cli@v2
+        with:
+          token: ${{ secrets.SENTRY_AUTH_TOKEN }}
+
+      - name: Build Windows remote server bundle
+        run: ./script/bundle-windows.ps1 -Architecture aarch64
+        shell: pwsh
+
+      - name: Upload remote server artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: zed-remote-server-windows-aarch64.zip
+          path: target/zed-remote-server-windows-aarch64.zip
+          if-no-files-found: error
+
+  bundle-windows-x86_64-remote-server:
+    name: Bundle Windows remote server (x86_64)
+    runs-on: self-32vcpu-windows-2022
+    env:
+      AZURE_TENANT_ID: ${{ secrets.AZURE_SIGNING_TENANT_ID }}
+      AZURE_CLIENT_ID: ${{ secrets.AZURE_SIGNING_CLIENT_ID }}
+      AZURE_CLIENT_SECRET: ${{ secrets.AZURE_SIGNING_CLIENT_SECRET }}
+      ACCOUNT_NAME: ${{ vars.AZURE_SIGNING_ACCOUNT_NAME }}
+      CERT_PROFILE_NAME: ${{ vars.AZURE_SIGNING_CERT_PROFILE_NAME }}
+      ENDPOINT: ${{ vars.AZURE_SIGNING_ENDPOINT }}
+      FILE_DIGEST: SHA256
+      TIMESTAMP_DIGEST: SHA256
+      TIMESTAMP_SERVER: http://timestamp.acs.microsoft.com
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          clean: false
+
+      - name: Setup Sentry
+        uses: matbour/setup-sentry-cli@v2
+        with:
+          token: ${{ secrets.SENTRY_AUTH_TOKEN }}
+
+      - name: Build Windows remote server bundle
+        run: ./script/bundle-windows.ps1 -Architecture x86_64
+        shell: pwsh
+
+      - name: Upload remote server artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: zed-remote-server-windows-x86_64.zip
+          path: target/zed-remote-server-windows-x86_64.zip
+          if-no-files-found: error
 
   create-release:
     name: Create GitHub Release
-    needs: [build-macos]
+    needs:
+      - build-macos
+      - bundle-macos-x86_64-remote-server
+      - bundle-linux-aarch64-remote-server
+      - bundle-linux-x86_64-remote-server
+      - bundle-windows-aarch64-remote-server
+      - bundle-windows-x86_64-remote-server
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -937,9 +1119,11 @@ jobs:
             artifacts/Glass-aarch64.dmg/Glass-aarch64.dmg
             artifacts/Glass-aarch64-symbols.zip/Glass-aarch64-symbols.zip
             artifacts/zed-remote-server-macos-aarch64.gz/zed-remote-server-macos-aarch64.gz
-            # Intel build disabled - uncomment when re-enabled:
-            # artifacts/Glass-x86_64.dmg/Glass-x86_64.dmg
-            # artifacts/zed-remote-server-macos-x86_64.gz/zed-remote-server-macos-x86_64.gz
+            artifacts/zed-remote-server-macos-x86_64.gz/zed-remote-server-macos-x86_64.gz
+            artifacts/zed-remote-server-linux-aarch64.gz/zed-remote-server-linux-aarch64.gz
+            artifacts/zed-remote-server-linux-x86_64.gz/zed-remote-server-linux-x86_64.gz
+            artifacts/zed-remote-server-windows-aarch64.zip/zed-remote-server-windows-aarch64.zip
+            artifacts/zed-remote-server-windows-x86_64.zip/zed-remote-server-windows-x86_64.zip
           body: |
             ## Glass ${{ env.RELEASE_VERSION }}
 
@@ -950,3 +1134,27 @@ jobs:
             3. Launch Glass from Applications
 
             > **Note:** Only Apple Silicon builds are available at this time. Intel Mac support coming later.
+
+  validate-release-assets:
+    name: Validate release assets
+    needs: [create-release]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Verify all expected release assets are present
+        run: |
+          EXPECTED_ASSETS='["Glass-aarch64.dmg","Glass-aarch64-symbols.zip","zed-remote-server-macos-aarch64.gz","zed-remote-server-macos-x86_64.gz","zed-remote-server-linux-aarch64.gz","zed-remote-server-linux-x86_64.gz","zed-remote-server-windows-aarch64.zip","zed-remote-server-windows-x86_64.zip"]'
+          ACTUAL_ASSETS=$(gh release view "${{ env.RELEASE_VERSION }}" --repo Glass-HQ/Glass --json assets -q '[.assets[].name]')
+          MISSING_ASSETS=$(echo "$EXPECTED_ASSETS" | jq -r --argjson actual "$ACTUAL_ASSETS" '. - $actual | .[]')
+
+          if [ -n "$MISSING_ASSETS" ]; then
+            echo "Missing release assets:"
+            echo "$MISSING_ASSETS"
+            exit 1
+          fi
+
+          echo "All expected release assets are present."
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release_nightly.yml
+++ b/.github/workflows/release_nightly.yml
@@ -241,7 +241,7 @@ jobs:
     - check_style
     - run_tests_windows
     - clippy_windows
-    runs-on: namespace-profile-mac-large
+    runs-on: macos-15-intel
     env:
       CARGO_INCREMENTAL: 0
       ZED_CLIENT_CHECKSUM_SEED: ${{ secrets.ZED_CLIENT_CHECKSUM_SEED }}

--- a/.github/workflows/run_bundling.yml
+++ b/.github/workflows/run_bundling.yml
@@ -136,7 +136,7 @@ jobs:
     if: |-
       (github.event.action == 'labeled' && github.event.label.name == 'run-bundling') ||
       (github.event.action == 'synchronize' && contains(github.event.pull_request.labels.*.name, 'run-bundling'))
-    runs-on: namespace-profile-mac-large
+    runs-on: macos-15-intel
     env:
       CARGO_INCREMENTAL: 0
       ZED_CLIENT_CHECKSUM_SEED: ${{ secrets.ZED_CLIENT_CHECKSUM_SEED }}

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -15,7 +15,7 @@ on:
     - v[0-9]+.[0-9]+.x
 jobs:
   orchestrate:
-    if: (github.repository_owner == 'zed-industries' || github.repository_owner == 'zed-extensions')
+    if: (github.repository_owner == 'zed-industries' || github.repository_owner == 'zed-extensions' || github.repository_owner == 'Glass-HQ')
     runs-on: namespace-profile-2x4-ubuntu-2404
     steps:
     - name: steps::checkout_repo
@@ -128,7 +128,7 @@ jobs:
       run_tests: ${{ steps.filter.outputs.run_tests }}
       changed_extensions: ${{ steps.filter.outputs.changed_extensions }}
   check_style:
-    if: (github.repository_owner == 'zed-industries' || github.repository_owner == 'zed-extensions')
+    if: (github.repository_owner == 'zed-industries' || github.repository_owner == 'zed-extensions' || github.repository_owner == 'Glass-HQ')
     runs-on: namespace-profile-4x8-ubuntu-2204
     steps:
     - name: steps::checkout_repo
@@ -807,7 +807,7 @@ jobs:
     - check_licenses
     - check_scripts
     - extension_tests
-    if: (github.repository_owner == 'zed-industries' || github.repository_owner == 'zed-extensions') && always()
+    if: (github.repository_owner == 'zed-industries' || github.repository_owner == 'zed-extensions' || github.repository_owner == 'Glass-HQ') && always()
     runs-on: namespace-profile-2x4-ubuntu-2404
     steps:
     - name: run_tests::tests_pass

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1957,7 +1957,7 @@ dependencies = [
  "bitflags 2.10.0",
  "cexpr",
  "clang-sys",
- "itertools 0.11.0",
+ "itertools 0.10.5",
  "log",
  "prettyplease",
  "proc-macro2",
@@ -1977,7 +1977,7 @@ dependencies = [
  "bitflags 2.10.0",
  "cexpr",
  "clang-sys",
- "itertools 0.11.0",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "regex",
@@ -3346,7 +3346,7 @@ dependencies = [
 [[package]]
 name = "collections"
 version = "0.1.0"
-source = "git+https://github.com/Glass-HQ/gpui.git?rev=3790fca95dbf00918859192c8f51a35f1c46a444#3790fca95dbf00918859192c8f51a35f1c46a444"
+source = "git+https://github.com/Glass-HQ/gpui.git?rev=23b0a377d551cf1356fc942aaba2d6958d9777cd#23b0a377d551cf1356fc942aaba2d6958d9777cd"
 dependencies = [
  "indexmap",
  "rustc-hash 2.1.1",
@@ -5032,7 +5032,7 @@ dependencies = [
 [[package]]
 name = "derive_refineable"
 version = "0.1.0"
-source = "git+https://github.com/Glass-HQ/gpui.git?rev=3790fca95dbf00918859192c8f51a35f1c46a444#3790fca95dbf00918859192c8f51a35f1c46a444"
+source = "git+https://github.com/Glass-HQ/gpui.git?rev=23b0a377d551cf1356fc942aaba2d6958d9777cd#23b0a377d551cf1356fc942aaba2d6958d9777cd"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7277,7 +7277,7 @@ dependencies = [
  "libc",
  "log",
  "rustversion",
- "windows 0.61.3",
+ "windows 0.58.0",
 ]
 
 [[package]]
@@ -7747,7 +7747,7 @@ dependencies = [
  "log",
  "presser",
  "thiserror 2.0.17",
- "windows 0.62.2",
+ "windows 0.58.0",
 ]
 
 [[package]]
@@ -7773,7 +7773,7 @@ dependencies = [
 [[package]]
 name = "gpui"
 version = "0.2.2"
-source = "git+https://github.com/Glass-HQ/gpui.git?rev=3790fca95dbf00918859192c8f51a35f1c46a444#3790fca95dbf00918859192c8f51a35f1c46a444"
+source = "git+https://github.com/Glass-HQ/gpui.git?rev=23b0a377d551cf1356fc942aaba2d6958d9777cd#23b0a377d551cf1356fc942aaba2d6958d9777cd"
 dependencies = [
  "anyhow",
  "async-channel 2.5.0",
@@ -7855,7 +7855,7 @@ dependencies = [
 [[package]]
 name = "gpui_ios"
 version = "0.1.0"
-source = "git+https://github.com/Glass-HQ/gpui.git?rev=3790fca95dbf00918859192c8f51a35f1c46a444#3790fca95dbf00918859192c8f51a35f1c46a444"
+source = "git+https://github.com/Glass-HQ/gpui.git?rev=23b0a377d551cf1356fc942aaba2d6958d9777cd#23b0a377d551cf1356fc942aaba2d6958d9777cd"
 dependencies = [
  "anyhow",
  "block",
@@ -7884,7 +7884,7 @@ dependencies = [
 [[package]]
 name = "gpui_linux"
 version = "0.1.0"
-source = "git+https://github.com/Glass-HQ/gpui.git?rev=3790fca95dbf00918859192c8f51a35f1c46a444#3790fca95dbf00918859192c8f51a35f1c46a444"
+source = "git+https://github.com/Glass-HQ/gpui.git?rev=23b0a377d551cf1356fc942aaba2d6958d9777cd#23b0a377d551cf1356fc942aaba2d6958d9777cd"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -7914,7 +7914,7 @@ dependencies = [
 [[package]]
 name = "gpui_macos"
 version = "0.1.0"
-source = "git+https://github.com/Glass-HQ/gpui.git?rev=3790fca95dbf00918859192c8f51a35f1c46a444#3790fca95dbf00918859192c8f51a35f1c46a444"
+source = "git+https://github.com/Glass-HQ/gpui.git?rev=23b0a377d551cf1356fc942aaba2d6958d9777cd#23b0a377d551cf1356fc942aaba2d6958d9777cd"
 dependencies = [
  "anyhow",
  "async-task",
@@ -7955,7 +7955,7 @@ dependencies = [
 [[package]]
 name = "gpui_macros"
 version = "0.1.0"
-source = "git+https://github.com/Glass-HQ/gpui.git?rev=3790fca95dbf00918859192c8f51a35f1c46a444#3790fca95dbf00918859192c8f51a35f1c46a444"
+source = "git+https://github.com/Glass-HQ/gpui.git?rev=23b0a377d551cf1356fc942aaba2d6958d9777cd#23b0a377d551cf1356fc942aaba2d6958d9777cd"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -7966,7 +7966,7 @@ dependencies = [
 [[package]]
 name = "gpui_metal"
 version = "0.1.0"
-source = "git+https://github.com/Glass-HQ/gpui.git?rev=3790fca95dbf00918859192c8f51a35f1c46a444#3790fca95dbf00918859192c8f51a35f1c46a444"
+source = "git+https://github.com/Glass-HQ/gpui.git?rev=23b0a377d551cf1356fc942aaba2d6958d9777cd#23b0a377d551cf1356fc942aaba2d6958d9777cd"
 dependencies = [
  "anyhow",
  "block",
@@ -7991,7 +7991,7 @@ dependencies = [
 [[package]]
 name = "gpui_platform"
 version = "0.1.0"
-source = "git+https://github.com/Glass-HQ/gpui.git?rev=3790fca95dbf00918859192c8f51a35f1c46a444#3790fca95dbf00918859192c8f51a35f1c46a444"
+source = "git+https://github.com/Glass-HQ/gpui.git?rev=23b0a377d551cf1356fc942aaba2d6958d9777cd#23b0a377d551cf1356fc942aaba2d6958d9777cd"
 dependencies = [
  "console_error_panic_hook",
  "gpui",
@@ -8012,7 +8012,7 @@ dependencies = [
 [[package]]
 name = "gpui_tokio"
 version = "0.1.0"
-source = "git+https://github.com/Glass-HQ/gpui.git?rev=3790fca95dbf00918859192c8f51a35f1c46a444#3790fca95dbf00918859192c8f51a35f1c46a444"
+source = "git+https://github.com/Glass-HQ/gpui.git?rev=23b0a377d551cf1356fc942aaba2d6958d9777cd#23b0a377d551cf1356fc942aaba2d6958d9777cd"
 dependencies = [
  "anyhow",
  "gpui",
@@ -8023,7 +8023,7 @@ dependencies = [
 [[package]]
 name = "gpui_util"
 version = "0.1.0"
-source = "git+https://github.com/Glass-HQ/gpui.git?rev=3790fca95dbf00918859192c8f51a35f1c46a444#3790fca95dbf00918859192c8f51a35f1c46a444"
+source = "git+https://github.com/Glass-HQ/gpui.git?rev=23b0a377d551cf1356fc942aaba2d6958d9777cd#23b0a377d551cf1356fc942aaba2d6958d9777cd"
 dependencies = [
  "anyhow",
  "log",
@@ -8032,7 +8032,7 @@ dependencies = [
 [[package]]
 name = "gpui_web"
 version = "0.1.0"
-source = "git+https://github.com/Glass-HQ/gpui.git?rev=3790fca95dbf00918859192c8f51a35f1c46a444#3790fca95dbf00918859192c8f51a35f1c46a444"
+source = "git+https://github.com/Glass-HQ/gpui.git?rev=23b0a377d551cf1356fc942aaba2d6958d9777cd#23b0a377d551cf1356fc942aaba2d6958d9777cd"
 dependencies = [
  "anyhow",
  "console_error_panic_hook",
@@ -8056,7 +8056,7 @@ dependencies = [
 [[package]]
 name = "gpui_wgpu"
 version = "0.1.0"
-source = "git+https://github.com/Glass-HQ/gpui.git?rev=3790fca95dbf00918859192c8f51a35f1c46a444#3790fca95dbf00918859192c8f51a35f1c46a444"
+source = "git+https://github.com/Glass-HQ/gpui.git?rev=23b0a377d551cf1356fc942aaba2d6958d9777cd#23b0a377d551cf1356fc942aaba2d6958d9777cd"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -8083,7 +8083,7 @@ dependencies = [
 [[package]]
 name = "gpui_windows"
 version = "0.1.0"
-source = "git+https://github.com/Glass-HQ/gpui.git?rev=3790fca95dbf00918859192c8f51a35f1c46a444#3790fca95dbf00918859192c8f51a35f1c46a444"
+source = "git+https://github.com/Glass-HQ/gpui.git?rev=23b0a377d551cf1356fc942aaba2d6958d9777cd#23b0a377d551cf1356fc942aaba2d6958d9777cd"
 dependencies = [
  "anyhow",
  "collections",
@@ -8565,7 +8565,7 @@ checksum = "add0ab9360ddbd88cfeb3bd9574a1d85cfdfa14db10b3e21d3700dbc4328758f"
 [[package]]
 name = "http_client"
 version = "0.1.0"
-source = "git+https://github.com/Glass-HQ/gpui.git?rev=3790fca95dbf00918859192c8f51a35f1c46a444#3790fca95dbf00918859192c8f51a35f1c46a444"
+source = "git+https://github.com/Glass-HQ/gpui.git?rev=23b0a377d551cf1356fc942aaba2d6958d9777cd#23b0a377d551cf1356fc942aaba2d6958d9777cd"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -8590,7 +8590,7 @@ dependencies = [
 [[package]]
 name = "http_client_tls"
 version = "0.1.0"
-source = "git+https://github.com/Glass-HQ/gpui.git?rev=3790fca95dbf00918859192c8f51a35f1c46a444#3790fca95dbf00918859192c8f51a35f1c46a444"
+source = "git+https://github.com/Glass-HQ/gpui.git?rev=23b0a377d551cf1356fc942aaba2d6958d9777cd#23b0a377d551cf1356fc942aaba2d6958d9777cd"
 dependencies = [
  "rustls 0.23.33",
  "rustls-platform-verifier",
@@ -8762,7 +8762,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core 0.58.0",
 ]
 
 [[package]]
@@ -10709,7 +10709,7 @@ dependencies = [
 [[package]]
 name = "media"
 version = "0.1.0"
-source = "git+https://github.com/Glass-HQ/gpui.git?rev=3790fca95dbf00918859192c8f51a35f1c46a444#3790fca95dbf00918859192c8f51a35f1c46a444"
+source = "git+https://github.com/Glass-HQ/gpui.git?rev=23b0a377d551cf1356fc942aaba2d6958d9777cd#23b0a377d551cf1356fc942aaba2d6958d9777cd"
 dependencies = [
  "anyhow",
  "bindgen 0.71.1",
@@ -13828,7 +13828,7 @@ checksum = "22505a5c94da8e3b7c2996394d1c933236c4d743e81a410bcca4e6989fc066a4"
 dependencies = [
  "bytes 1.11.1",
  "heck 0.5.0",
- "itertools 0.11.0",
+ "itertools 0.10.5",
  "log",
  "multimap",
  "once_cell",
@@ -13861,7 +13861,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81bddcdb20abf9501610992b6759a4c888aef7d1a7247ef75e2404275ac24af1"
 dependencies = [
  "anyhow",
- "itertools 0.11.0",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -14590,7 +14590,7 @@ dependencies = [
 [[package]]
 name = "refineable"
 version = "0.1.0"
-source = "git+https://github.com/Glass-HQ/gpui.git?rev=3790fca95dbf00918859192c8f51a35f1c46a444#3790fca95dbf00918859192c8f51a35f1c46a444"
+source = "git+https://github.com/Glass-HQ/gpui.git?rev=23b0a377d551cf1356fc942aaba2d6958d9777cd#23b0a377d551cf1356fc942aaba2d6958d9777cd"
 dependencies = [
  "derive_refineable",
 ]
@@ -15568,7 +15568,7 @@ dependencies = [
 [[package]]
 name = "scheduler"
 version = "0.1.0"
-source = "git+https://github.com/Glass-HQ/gpui.git?rev=3790fca95dbf00918859192c8f51a35f1c46a444#3790fca95dbf00918859192c8f51a35f1c46a444"
+source = "git+https://github.com/Glass-HQ/gpui.git?rev=23b0a377d551cf1356fc942aaba2d6958d9777cd#23b0a377d551cf1356fc942aaba2d6958d9777cd"
 dependencies = [
  "async-task",
  "backtrace",
@@ -17179,7 +17179,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 [[package]]
 name = "sum_tree"
 version = "0.1.0"
-source = "git+https://github.com/Glass-HQ/gpui.git?rev=3790fca95dbf00918859192c8f51a35f1c46a444#3790fca95dbf00918859192c8f51a35f1c46a444"
+source = "git+https://github.com/Glass-HQ/gpui.git?rev=23b0a377d551cf1356fc942aaba2d6958d9777cd#23b0a377d551cf1356fc942aaba2d6958d9777cd"
 dependencies = [
  "heapless",
  "log",
@@ -19524,7 +19524,7 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 [[package]]
 name = "util"
 version = "0.1.0"
-source = "git+https://github.com/Glass-HQ/gpui.git?rev=3790fca95dbf00918859192c8f51a35f1c46a444#3790fca95dbf00918859192c8f51a35f1c46a444"
+source = "git+https://github.com/Glass-HQ/gpui.git?rev=23b0a377d551cf1356fc942aaba2d6958d9777cd#23b0a377d551cf1356fc942aaba2d6958d9777cd"
 dependencies = [
  "anyhow",
  "async-fs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -283,7 +283,7 @@ cloud_api_types = { path = "crates/cloud_api_types" }
 cloud_llm_client = { path = "crates/cloud_llm_client" }
 collab = { path = "crates/collab" }
 collab_ui = { path = "crates/collab_ui" }
-collections = { git = "https://github.com/Glass-HQ/gpui.git", rev = "3790fca95dbf00918859192c8f51a35f1c46a444", version = "0.1.0" }
+collections = { git = "https://github.com/Glass-HQ/gpui.git", rev = "23b0a377d551cf1356fc942aaba2d6958d9777cd", version = "0.1.0" }
 command_palette = { path = "crates/command_palette" }
 command_palette_hooks = { path = "crates/command_palette_hooks" }
 compliance = { path = "tooling/compliance" }
@@ -304,7 +304,7 @@ debug_adapter_extension = { path = "crates/debug_adapter_extension" }
 debugger_tools = { path = "crates/debugger_tools" }
 debugger_ui = { path = "crates/debugger_ui" }
 deepseek = { path = "crates/deepseek" }
-derive_refineable = { git = "https://github.com/Glass-HQ/gpui.git", rev = "3790fca95dbf00918859192c8f51a35f1c46a444" }
+derive_refineable = { git = "https://github.com/Glass-HQ/gpui.git", rev = "23b0a377d551cf1356fc942aaba2d6958d9777cd" }
 dev_container = { path = "crates/dev_container" }
 diagnostics = { path = "crates/diagnostics" }
 editor = { path = "crates/editor" }
@@ -329,15 +329,15 @@ git_ui = { path = "crates/git_ui" }
 go_to_line = { path = "crates/go_to_line" }
 google_ai = { path = "crates/google_ai" }
 grammars = { path = "crates/grammars" }
-gpui = { git = "https://github.com/Glass-HQ/gpui.git", rev = "3790fca95dbf00918859192c8f51a35f1c46a444", default-features = false }
+gpui = { git = "https://github.com/Glass-HQ/gpui.git", rev = "23b0a377d551cf1356fc942aaba2d6958d9777cd", default-features = false }
 gpui_shared_string = { path = "crates/gpui_shared_string" }
-gpui_macros = { git = "https://github.com/Glass-HQ/gpui.git", rev = "3790fca95dbf00918859192c8f51a35f1c46a444" }
-gpui_platform = { git = "https://github.com/Glass-HQ/gpui.git", rev = "3790fca95dbf00918859192c8f51a35f1c46a444", default-features = false, features = ["font-kit"] }
-gpui_tokio = { git = "https://github.com/Glass-HQ/gpui.git", rev = "3790fca95dbf00918859192c8f51a35f1c46a444" }
-gpui_util = { git = "https://github.com/Glass-HQ/gpui.git", rev = "3790fca95dbf00918859192c8f51a35f1c46a444" }
+gpui_macros = { git = "https://github.com/Glass-HQ/gpui.git", rev = "23b0a377d551cf1356fc942aaba2d6958d9777cd" }
+gpui_platform = { git = "https://github.com/Glass-HQ/gpui.git", rev = "23b0a377d551cf1356fc942aaba2d6958d9777cd", default-features = false, features = ["font-kit"] }
+gpui_tokio = { git = "https://github.com/Glass-HQ/gpui.git", rev = "23b0a377d551cf1356fc942aaba2d6958d9777cd" }
+gpui_util = { git = "https://github.com/Glass-HQ/gpui.git", rev = "23b0a377d551cf1356fc942aaba2d6958d9777cd" }
 html_to_markdown = { path = "crates/html_to_markdown" }
-http_client = { git = "https://github.com/Glass-HQ/gpui.git", rev = "3790fca95dbf00918859192c8f51a35f1c46a444" }
-http_client_tls = { git = "https://github.com/Glass-HQ/gpui.git", rev = "3790fca95dbf00918859192c8f51a35f1c46a444" }
+http_client = { git = "https://github.com/Glass-HQ/gpui.git", rev = "23b0a377d551cf1356fc942aaba2d6958d9777cd" }
+http_client_tls = { git = "https://github.com/Glass-HQ/gpui.git", rev = "23b0a377d551cf1356fc942aaba2d6958d9777cd" }
 icons = { path = "crates/icons" }
 image_viewer = { path = "crates/image_viewer" }
 edit_prediction_types = { path = "crates/edit_prediction_types" }
@@ -366,7 +366,7 @@ lsp = { path = "crates/lsp" }
 markdown = { path = "crates/markdown" }
 markdown_preview = { path = "crates/markdown_preview" }
 svg_preview = { path = "crates/svg_preview" }
-media = { git = "https://github.com/Glass-HQ/gpui.git", rev = "3790fca95dbf00918859192c8f51a35f1c46a444" }
+media = { git = "https://github.com/Glass-HQ/gpui.git", rev = "23b0a377d551cf1356fc942aaba2d6958d9777cd" }
 menu = { path = "crates/menu" }
 mermaid-rs-renderer = { git = "https://github.com/zed-industries/mermaid-rs-renderer", rev = "374db9ead5426697c6c2111151d9f246899bc638", default-features = false }
 migrator = { path = "crates/migrator" }
@@ -397,7 +397,7 @@ project_symbols = { path = "crates/project_symbols" }
 prompt_store = { path = "crates/prompt_store" }
 proto = { path = "crates/proto" }
 recent_projects = { path = "crates/recent_projects" }
-refineable = { git = "https://github.com/Glass-HQ/gpui.git", rev = "3790fca95dbf00918859192c8f51a35f1c46a444" }
+refineable = { git = "https://github.com/Glass-HQ/gpui.git", rev = "23b0a377d551cf1356fc942aaba2d6958d9777cd" }
 release_channel = { path = "crates/release_channel" }
 remote = { path = "crates/remote" }
 remote_connection = { path = "crates/remote_connection" }
@@ -408,7 +408,7 @@ rodio = { git = "https://github.com/RustAudio/rodio", rev = "e50e726ddd0292f6ef9
 rope = { path = "crates/rope" }
 rpc = { path = "crates/rpc" }
 rules_library = { path = "crates/rules_library" }
-scheduler = { git = "https://github.com/Glass-HQ/gpui.git", rev = "3790fca95dbf00918859192c8f51a35f1c46a444" }
+scheduler = { git = "https://github.com/Glass-HQ/gpui.git", rev = "23b0a377d551cf1356fc942aaba2d6958d9777cd" }
 search = { path = "crates/search" }
 service_hub = { path = "crates/service_hub" }
 service_hub_ui = { path = "crates/service_hub_ui" }
@@ -426,7 +426,7 @@ snippets_ui = { path = "crates/snippets_ui" }
 sqlez = { path = "crates/sqlez" }
 sqlez_macros = { path = "crates/sqlez_macros" }
 streaming_diff = { path = "crates/streaming_diff" }
-sum_tree = { git = "https://github.com/Glass-HQ/gpui.git", rev = "3790fca95dbf00918859192c8f51a35f1c46a444" }
+sum_tree = { git = "https://github.com/Glass-HQ/gpui.git", rev = "23b0a377d551cf1356fc942aaba2d6958d9777cd" }
 codestral = { path = "crates/codestral" }
 system_specs = { path = "crates/system_specs" }
 syntax_theme = { path = "crates/syntax_theme" }
@@ -451,7 +451,7 @@ ui = { path = "crates/ui" }
 ui_input = { path = "crates/ui_input" }
 ui_macros = { path = "crates/ui_macros" }
 ui_prompt = { path = "crates/ui_prompt" }
-util = { git = "https://github.com/Glass-HQ/gpui.git", rev = "3790fca95dbf00918859192c8f51a35f1c46a444" }
+util = { git = "https://github.com/Glass-HQ/gpui.git", rev = "23b0a377d551cf1356fc942aaba2d6958d9777cd" }
 util_macros = { path = "crates/util_macros" }
 vercel = { path = "crates/vercel" }
 vim = { path = "crates/vim" }

--- a/crates/auto_update/src/auto_update.rs
+++ b/crates/auto_update/src/auto_update.rs
@@ -591,15 +591,6 @@ impl AutoUpdater {
         arch: &str,
         cx: &mut AsyncApp,
     ) -> Result<Option<String>> {
-        // First, try fetching the remote server binary from Glass's GitHub Releases.
-        // Glass publishes these as release assets (e.g., zed-remote-server-linux-x86_64.gz).
-        if let Some(url) =
-            Self::get_github_release_remote_server_url(version.as_ref(), os, arch, cx).await?
-        {
-            return Ok(Some(url));
-        }
-
-        // Fall back to the upstream cloud API for compatibility.
         let this = cx.update(|cx| {
             cx.default_global::<GlobalAutoUpdate>()
                 .0
@@ -614,74 +605,24 @@ impl AutoUpdater {
         Ok(Some(release.url))
     }
 
-    /// Fetches the remote server download URL directly from Glass's GitHub Releases,
-    /// bypassing the Zed cloud API which does not host Glass release assets.
-    async fn get_github_release_remote_server_url(
+    fn get_glass_remote_server_release_asset(
         version: Option<&Version>,
         os: &str,
         arch: &str,
-        cx: &mut AsyncApp,
-    ) -> Result<Option<String>> {
-        const GLASS_GITHUB_RELEASES_API: &str =
-            "https://api.github.com/repos/Glass-HQ/Glass/releases";
+    ) -> Option<ReleaseAsset> {
+        let mut version = version?.clone();
+        version.pre = semver::Prerelease::EMPTY;
+        version.build = semver::BuildMetadata::EMPTY;
+        let version = version.to_string();
+        let extension = if os == "windows" { "zip" } else { "gz" };
+        let asset_name = format!("zed-remote-server-{os}-{arch}.{extension}");
 
-        let this = cx.update(|cx| {
-            cx.default_global::<GlobalAutoUpdate>()
-                .0
-                .clone()
-                .context("auto-update not initialized")
-        })?;
-        let http_client = this.read_with(cx, |this, _| this.client.http_client());
-
-        // Determine which release to fetch: specific version tag or latest.
-        let api_url = if let Some(v) = version {
-            format!("{}/tags/v{}", GLASS_GITHUB_RELEASES_API, v)
-        } else {
-            format!("{}/latest", GLASS_GITHUB_RELEASES_API)
-        };
-
-        let mut response = http_client
-            .get(&api_url, Default::default(), true)
-            .await?;
-
-        if !response.status().is_success() {
-            log::warn!(
-                "Glass GitHub Releases API returned {}: falling back to cloud API",
-                response.status()
-            );
-            return Ok(None);
-        }
-
-        let mut body = Vec::new();
-        response.body_mut().read_to_end(&mut body).await?;
-
-        let release: serde_json::Value = serde_json::from_slice(&body)?;
-        let asset_name = format!("zed-remote-server-{}-{}.gz", os, arch);
-
-        if let Some(assets) = release.get("assets").and_then(|a| a.as_array()) {
-            for asset in assets {
-                if let (Some(name), Some(url)) = (
-                    asset.get("name").and_then(|n| n.as_str()),
-                    asset
-                        .get("browser_download_url")
-                        .and_then(|u| u.as_str()),
-                ) {
-                    if name == asset_name {
-                        log::info!(
-                            "Found remote server binary in Glass GitHub Release: {}",
-                            url
-                        );
-                        return Ok(Some(url.to_string()));
-                    }
-                }
-            }
-        }
-
-        log::warn!(
-            "Remote server asset '{}' not found in Glass GitHub Release",
-            asset_name
-        );
-        Ok(None)
+        Some(ReleaseAsset {
+            version: version.clone(),
+            url: format!(
+                "https://github.com/Glass-HQ/Glass/releases/download/v{version}/{asset_name}"
+            ),
+        })
     }
 
     async fn get_release_asset(
@@ -693,6 +634,13 @@ impl AutoUpdater {
         arch: &str,
         cx: &mut AsyncApp,
     ) -> Result<ReleaseAsset> {
+        if asset == "zed-remote-server"
+            && let Some(release) =
+                Self::get_glass_remote_server_release_asset(version.as_ref(), os, arch)
+        {
+            return Ok(release);
+        }
+
         let client = this.read_with(cx, |this, _| this.client.clone());
 
         let (system_id, metrics_id, is_staff) = if client.telemetry().metrics_enabled() {
@@ -1278,6 +1226,61 @@ mod tests {
 
     pub(super) struct InstallOverride(pub Rc<dyn Fn(&Path, &AsyncApp) -> Result<Option<PathBuf>>>);
     impl Global for InstallOverride {}
+
+    #[test]
+    fn test_glass_remote_server_release_asset_uses_github_release_downloads() {
+        let release = AutoUpdater::get_glass_remote_server_release_asset(
+            Some(&Version::new(0, 0, 1)),
+            "linux",
+            "x86_64",
+        )
+        .unwrap();
+
+        assert_eq!(release.version, "0.0.1");
+        assert_eq!(
+            release.url,
+            "https://github.com/Glass-HQ/Glass/releases/download/v0.0.1/zed-remote-server-linux-x86_64.gz"
+        );
+    }
+
+    #[test]
+    fn test_glass_remote_server_release_asset_uses_zip_for_windows() {
+        let release = AutoUpdater::get_glass_remote_server_release_asset(
+            Some(&Version::new(0, 0, 1)),
+            "windows",
+            "aarch64",
+        )
+        .unwrap();
+
+        assert_eq!(
+            release.url,
+            "https://github.com/Glass-HQ/Glass/releases/download/v0.0.1/zed-remote-server-windows-aarch64.zip"
+        );
+    }
+
+    #[test]
+    fn test_glass_remote_server_release_asset_strips_version_metadata() {
+        let mut version = Version::new(0, 0, 1);
+        version.pre = semver::Prerelease::new("stable.48").unwrap();
+        version.build = semver::BuildMetadata::new("abcdef0").unwrap();
+
+        let release =
+            AutoUpdater::get_glass_remote_server_release_asset(Some(&version), "macos", "aarch64")
+                .unwrap();
+
+        assert_eq!(release.version, "0.0.1");
+        assert_eq!(
+            release.url,
+            "https://github.com/Glass-HQ/Glass/releases/download/v0.0.1/zed-remote-server-macos-aarch64.gz"
+        );
+    }
+
+    #[test]
+    fn test_glass_remote_server_release_asset_requires_a_version() {
+        assert!(
+            AutoUpdater::get_glass_remote_server_release_asset(None, "linux", "x86_64").is_none()
+        );
+    }
 
     #[gpui::test]
     fn test_auto_update_defaults_to_true(cx: &mut TestAppContext) {

--- a/crates/auto_update/src/auto_update.rs
+++ b/crates/auto_update/src/auto_update.rs
@@ -591,6 +591,15 @@ impl AutoUpdater {
         arch: &str,
         cx: &mut AsyncApp,
     ) -> Result<Option<String>> {
+        // First, try fetching the remote server binary from Glass's GitHub Releases.
+        // Glass publishes these as release assets (e.g., zed-remote-server-linux-x86_64.gz).
+        if let Some(url) =
+            Self::get_github_release_remote_server_url(version.as_ref(), os, arch, cx).await?
+        {
+            return Ok(Some(url));
+        }
+
+        // Fall back to the upstream cloud API for compatibility.
         let this = cx.update(|cx| {
             cx.default_global::<GlobalAutoUpdate>()
                 .0
@@ -603,6 +612,76 @@ impl AutoUpdater {
                 .await?;
 
         Ok(Some(release.url))
+    }
+
+    /// Fetches the remote server download URL directly from Glass's GitHub Releases,
+    /// bypassing the Zed cloud API which does not host Glass release assets.
+    async fn get_github_release_remote_server_url(
+        version: Option<&Version>,
+        os: &str,
+        arch: &str,
+        cx: &mut AsyncApp,
+    ) -> Result<Option<String>> {
+        const GLASS_GITHUB_RELEASES_API: &str =
+            "https://api.github.com/repos/Glass-HQ/Glass/releases";
+
+        let this = cx.update(|cx| {
+            cx.default_global::<GlobalAutoUpdate>()
+                .0
+                .clone()
+                .context("auto-update not initialized")
+        })?;
+        let http_client = this.read_with(cx, |this, _| this.client.http_client());
+
+        // Determine which release to fetch: specific version tag or latest.
+        let api_url = if let Some(v) = version {
+            format!("{}/tags/v{}", GLASS_GITHUB_RELEASES_API, v)
+        } else {
+            format!("{}/latest", GLASS_GITHUB_RELEASES_API)
+        };
+
+        let mut response = http_client
+            .get(&api_url, Default::default(), true)
+            .await?;
+
+        if !response.status().is_success() {
+            log::warn!(
+                "Glass GitHub Releases API returned {}: falling back to cloud API",
+                response.status()
+            );
+            return Ok(None);
+        }
+
+        let mut body = Vec::new();
+        response.body_mut().read_to_end(&mut body).await?;
+
+        let release: serde_json::Value = serde_json::from_slice(&body)?;
+        let asset_name = format!("zed-remote-server-{}-{}.gz", os, arch);
+
+        if let Some(assets) = release.get("assets").and_then(|a| a.as_array()) {
+            for asset in assets {
+                if let (Some(name), Some(url)) = (
+                    asset.get("name").and_then(|n| n.as_str()),
+                    asset
+                        .get("browser_download_url")
+                        .and_then(|u| u.as_str()),
+                ) {
+                    if name == asset_name {
+                        log::info!(
+                            "Found remote server binary in Glass GitHub Release: {}",
+                            url
+                        );
+                        return Ok(Some(url.to_string()));
+                    }
+                }
+            }
+        }
+
+        log::warn!(
+            "Remote server asset '{}' not found in Glass GitHub Release",
+            asset_name
+        );
+        Ok(None)
     }
 
     async fn get_release_asset(

--- a/crates/auto_update/src/auto_update.rs
+++ b/crates/auto_update/src/auto_update.rs
@@ -46,6 +46,10 @@ impl std::error::Error for MissingDependencyError {}
 const POLL_INTERVAL: Duration = Duration::from_secs(60 * 60);
 const REMOTE_SERVER_CACHE_LIMIT: usize = 5;
 
+fn remote_server_archive_extension(os: &str) -> &'static str {
+    if os == "windows" { "zip" } else { "gz" }
+}
+
 #[cfg(target_os = "linux")]
 fn linux_rsync_install_hint() -> &'static str {
     let os_release = match std::fs::read_to_string("/etc/os-release") {
@@ -557,7 +561,11 @@ impl AutoUpdater {
         let servers_dir = paths::remote_servers_dir();
         let channel_dir = servers_dir.join(release_channel.dev_name());
         let platform_dir = channel_dir.join(format!("{}-{}", os, arch));
-        let version_path = platform_dir.join(format!("{}.gz", release.version));
+        let version_path = platform_dir.join(format!(
+            "{}.{}",
+            release.version,
+            remote_server_archive_extension(os)
+        ));
         smol::fs::create_dir_all(&platform_dir).await.ok();
 
         let client = this.read_with(cx, |this, _| this.client.http_client());
@@ -614,7 +622,7 @@ impl AutoUpdater {
         version.pre = semver::Prerelease::EMPTY;
         version.build = semver::BuildMetadata::EMPTY;
         let version = version.to_string();
-        let extension = if os == "windows" { "zip" } else { "gz" };
+        let extension = remote_server_archive_extension(os);
         let asset_name = format!("zed-remote-server-{os}-{arch}.{extension}");
 
         Some(ReleaseAsset {
@@ -956,7 +964,10 @@ async fn cleanup_remote_server_cache(
     while let Some(entry) = entries.next().await {
         let entry = entry?;
         let path = entry.path();
-        if path.extension() != Some(OsStr::new("gz")) {
+        let Some(extension) = path.extension() else {
+            continue;
+        };
+        if extension != OsStr::new("gz") && extension != OsStr::new("zip") {
             continue;
         }
 
@@ -1280,6 +1291,21 @@ mod tests {
         assert!(
             AutoUpdater::get_glass_remote_server_release_asset(None, "linux", "x86_64").is_none()
         );
+    }
+
+    #[test]
+    fn test_cleanup_remote_server_cache_removes_old_zip_archives() {
+        let temp_dir = tempdir().unwrap();
+        let keep_path = temp_dir.path().join("0.0.2.zip");
+        let old_path = temp_dir.path().join("0.0.1.zip");
+
+        std::fs::write(&keep_path, b"current").unwrap();
+        std::fs::write(&old_path, b"old").unwrap();
+
+        smol::block_on(cleanup_remote_server_cache(temp_dir.path(), &keep_path, 1)).unwrap();
+
+        assert!(keep_path.exists());
+        assert!(!old_path.exists());
     }
 
     #[gpui::test]

--- a/script/bundle-mac
+++ b/script/bundle-mac
@@ -9,9 +9,9 @@ open_result=false
 local_install=false
 can_code_sign=false
 
-# This must match the team in the provisioning profile.
-IDENTITY="Zed Industries, Inc."
-APPLE_NOTARIZATION_TEAM="MQ55VZLNZQ"
+# This must match the Apple-issued Developer ID identity and team used for signing.
+IDENTITY="Developer ID Application: EasyLink (DA7B5U47PT)"
+APPLE_NOTARIZATION_TEAM="DA7B5U47PT"
 
 # Function for displaying help info
 help_info() {
@@ -214,8 +214,8 @@ function sign_app_binaries() {
 
         # NOTE: if you need to test universal links you have a few paths forward:
         # - create a PR and tag it with the `run-bundling` label, and download the .dmg file from there.
-        # - get a signing key for the MQ55VZLNZQ team from Nathan.
-        # - create your own signing key, and update references to MQ55VZLNZQ to your own team ID
+        # - get a signing key for the DA7B5U47PT team.
+        # - create your own signing key, and update references to DA7B5U47PT to your own team ID
         # then comment out this line.
         cat crates/zed/resources/zed.entitlements | sed '/com.apple.developer.associated-domains/,+1d' > "${app_path}/Contents/Resources/zed.entitlements"
 

--- a/script/bundle-mac
+++ b/script/bundle-mac
@@ -271,7 +271,7 @@ function sign_app_binaries() {
         if [[ $can_code_sign = true ]]; then
             echo "Notarizing DMG with Apple"
             /usr/bin/codesign --deep --force --timestamp --options runtime --sign "$IDENTITY" "$(pwd)/${dmg_file_path}" -v
-            echo "$APPLE_NOTARIZATION_KEY" > "$notarization_key_file"
+            echo "$APPLE_NOTARIZATION_KEY" | base64 --decode > "$notarization_key_file"
             "${xcode_bin_dir_path}/notarytool" submit --wait --key "$notarization_key_file" --key-id "$APPLE_NOTARIZATION_KEY_ID" --issuer "$APPLE_NOTARIZATION_ISSUER_ID" "${dmg_file_path}"
             rm "$notarization_key_file"
             "${xcode_bin_dir_path}/stapler" staple "${dmg_file_path}"


### PR DESCRIPTION
## Summary

Fixes #38 by publishing the remote server assets Glass needs for SSH remoting and by resolving those assets from Glass-owned releases instead of Zed's release service.

## What Changed

- Added the full remote-server asset matrix to `release_glass.yml`:
  - `zed-remote-server-macos-aarch64.gz`
  - `zed-remote-server-macos-x86_64.gz`
  - `zed-remote-server-linux-aarch64.gz`
  - `zed-remote-server-linux-x86_64.gz`
  - `zed-remote-server-windows-aarch64.zip`
  - `zed-remote-server-windows-x86_64.zip`
- Kept the Glass app release Mac-only for now while still publishing cross-platform remote-server assets for SSH remoting.
- Added a release validation job so future releases fail if any expected remote-server asset is missing.
- Updated `auto_update.rs` so remote server downloads use deterministic Glass GitHub release URLs for versioned builds. This fixes both remote-server download paths instead of only the direct URL branch.
- Set `ZED_APP_VERSION` from the release tag in every release build job and used the derived version in the macOS `Info.plist`, so released binaries request the matching remote-server assets.

## Why

Glass currently builds `remote_server` during releases but only publishes the Mac app DMG and symbols. Remote SSH then fails when Glass tries to fetch assets like `zed-remote-server-linux-x86_64.gz` that were never released.

The previous PR version only packaged a macOS asset and only changed one code path. That would not fix the original Linux remote-target failure or the local-download fallback path. It also would have left future releases vulnerable to version/tag mismatches.

## Verification

- `cargo test -p auto_update --lib test_glass_remote_server_release_asset_`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release_glass.yml"); puts "yaml ok"'`
- `git diff --check`

Notes:
- The new release-URL tests passed.
- A full `cargo test -p auto_update --lib` run reached the updated tests successfully, but an existing async test (`test_auto_update_downloads`) exceeded 60 seconds locally, so I did not treat that as a blocker for this change.

## Follow-up Manual Testing

1. Run `release_glass.yml` with a temporary release version to validate the workflow matrix.
2. Verify the release contains the eight expected assets: the Mac DMG, symbols zip, and six remote-server assets.
3. On the next real versioned release, verify runtime downloads against that matching release tag.
4. On macOS, SSH into a Linux `x86_64` VM and confirm Glass downloads the Linux remote server and opens the project.
5. On macOS, SSH into a macOS target and confirm the macOS remote server path works.
6. On Windows, SSH into a Linux VM and confirm the Linux remote server download path works.
7. On Windows, SSH into a Windows SSH target and confirm the Windows remote server download path works.

Release Notes:

- Fixed missing remote-server release assets that broke Remote SSH for Glass releases.
