### PR TITLE
browser: Reduce spurious rendering and lock contention

### DIFF
--- a/crates/browser/src/browser_view.rs
+++ b/crates/browser/src/browser_view.rs
@@ -848,7 +848,9 @@ impl BrowserView {
         match event {
             #[cfg(target_os = "macos")]
             TabEvent::FrameReady => {
-                cx.notify();
+                if self.surface_state == BrowserSurfaceState::Visible {
+                    cx.notify();
+                }
             }
             TabEvent::NavigateToUrl(url) => {
                 let url = url.clone();
@@ -1493,26 +1495,29 @@ impl Render for BrowserView {
             .into_any_element();
 
         #[cfg(not(target_os = "macos"))]
-        let element = match self.tab_bar_mode {
-            TabBarMode::Horizontal => element
-                .flex_col()
-                .child(div().mt(px(-1.)).child(self.render_tab_strip(cx)))
-                .child(self.bookmark_bar.clone())
-                .child(self.render_browser_content(window, cx))
-                .into_any_element(),
-            TabBarMode::Sidebar => element
-                .flex_row()
-                .child(self.render_sidebar(cx))
-                .child(
-                    div()
-                        .flex_1()
-                        .flex()
-                        .flex_col()
-                        .overflow_hidden()
-                        .child(self.bookmark_bar.clone())
-                        .child(self.render_browser_content(window, cx)),
-                )
-                .into_any_element(),
+        let element = {
+            let pinned_count = self.pinned_tab_count(cx);
+            match self.tab_bar_mode {
+                TabBarMode::Horizontal => element
+                    .flex_col()
+                    .child(div().mt(px(-1.)).child(self.render_tab_strip(pinned_count, cx)))
+                    .child(self.bookmark_bar.clone())
+                    .child(self.render_browser_content(window, cx))
+                    .into_any_element(),
+                TabBarMode::Sidebar => element
+                    .flex_row()
+                    .child(self.render_sidebar(pinned_count, cx))
+                    .child(
+                        div()
+                            .flex_1()
+                            .flex()
+                            .flex_col()
+                            .overflow_hidden()
+                            .child(self.bookmark_bar.clone())
+                            .child(self.render_browser_content(window, cx)),
+                    )
+                    .into_any_element(),
+            }
         };
 
         div()

--- a/crates/browser/src/browser_view/tab_strip.rs
+++ b/crates/browser/src/browser_view/tab_strip.rs
@@ -242,12 +242,19 @@ impl Render for BrowserSidebarPanel {
 
 impl BrowserView {
     #[cfg(not(target_os = "macos"))]
-    pub(super) fn render_tab_strip(&mut self, cx: &mut Context<Self>) -> impl IntoElement {
+    pub(super) fn pinned_tab_count(&self, cx: &mut gpui::Context<Self>) -> usize {
+        self.tabs.iter().filter(|t| t.read(cx).is_pinned()).count()
+    }
+
+    #[cfg(not(target_os = "macos"))]
+    pub(super) fn render_tab_strip(
+        &mut self,
+        pinned_count: usize,
+        cx: &mut Context<Self>,
+    ) -> impl IntoElement {
         let theme = cx.theme();
         let active_index = self.active_tab_index;
         let view = cx.entity().downgrade();
-
-        let pinned_count = self.tabs.iter().filter(|t| t.read(cx).is_pinned()).count();
 
         h_flex()
             .w_full()
@@ -613,12 +620,15 @@ impl BrowserView {
     }
 
     #[cfg(not(target_os = "macos"))]
-    pub(super) fn render_sidebar(&mut self, cx: &mut Context<Self>) -> impl IntoElement {
+    pub(super) fn render_sidebar(
+        &mut self,
+        pinned_count: usize,
+        cx: &mut Context<Self>,
+    ) -> impl IntoElement {
         let theme = cx.theme();
         let active_index = self.active_tab_index;
         let view = cx.entity().downgrade();
 
-        let pinned_count = self.tabs.iter().filter(|t| t.read(cx).is_pinned()).count();
         let grid_cols = pinned_count.min(3);
 
         v_flex()

--- a/crates/browser/src/client.rs
+++ b/crates/browser/src/client.rs
@@ -24,6 +24,8 @@ use crate::permission_handler::{OsrPermissionHandler, PermissionHandlerBuilder};
 use crate::render_handler::{OsrRenderHandler, RenderHandlerBuilder, RenderState};
 use crate::request_handler::{OsrRequestHandler, RequestHandlerBuilder};
 use crate::text_input::extract_text_input_state_from_message;
+#[cfg(target_os = "macos")]
+use core_video::pixel_buffer::CVPixelBuffer;
 use parking_lot::Mutex;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -189,16 +191,29 @@ wrap_client! {
 }
 
 impl ClientBuilder {
-    pub fn build(render_state: Arc<Mutex<RenderState>>, event_sender: EventSender) -> cef::Client {
-        Self::build_inner(render_state, event_sender, KeyboardHandlerBuilder::build())
-    }
-
-    pub fn build_for_popup(
+    pub fn build(
         render_state: Arc<Mutex<RenderState>>,
+        #[cfg(target_os = "macos")] current_frame: Arc<Mutex<Option<CVPixelBuffer>>>,
         event_sender: EventSender,
     ) -> cef::Client {
         Self::build_inner(
             render_state,
+            #[cfg(target_os = "macos")]
+            current_frame,
+            event_sender,
+            KeyboardHandlerBuilder::build(),
+        )
+    }
+
+    pub fn build_for_popup(
+        render_state: Arc<Mutex<RenderState>>,
+        #[cfg(target_os = "macos")] current_frame: Arc<Mutex<Option<CVPixelBuffer>>>,
+        event_sender: EventSender,
+    ) -> cef::Client {
+        Self::build_inner(
+            render_state,
+            #[cfg(target_os = "macos")]
+            current_frame,
             event_sender,
             PopupKeyboardHandlerBuilder::build(),
         )
@@ -206,10 +221,16 @@ impl ClientBuilder {
 
     fn build_inner(
         render_state: Arc<Mutex<RenderState>>,
+        #[cfg(target_os = "macos")] current_frame: Arc<Mutex<Option<CVPixelBuffer>>>,
         event_sender: EventSender,
         keyboard_handler: cef::KeyboardHandler,
     ) -> cef::Client {
-        let render_handler = OsrRenderHandler::new(render_state, event_sender.clone());
+        let render_handler = OsrRenderHandler::new(
+            render_state,
+            #[cfg(target_os = "macos")]
+            current_frame,
+            event_sender.clone(),
+        );
         let load_handler = OsrLoadHandler::new(event_sender.clone());
         let display_handler = OsrDisplayHandler::new(event_sender.clone());
         let life_span_handler = OsrLifeSpanHandler::new(event_sender.clone());

--- a/crates/browser/src/life_span_handler.rs
+++ b/crates/browser/src/life_span_handler.rs
@@ -11,6 +11,8 @@ use cef::{
     Browser, ImplLifeSpanHandler, LifeSpanHandler, WrapLifeSpanHandler, rc::Rc as _,
     wrap_life_span_handler,
 };
+#[cfg(target_os = "macos")]
+use core_video::pixel_buffer::CVPixelBuffer;
 use parking_lot::Mutex;
 use std::sync::Arc;
 
@@ -26,8 +28,15 @@ impl OsrLifeSpanHandler {
 
     fn popup_client() -> cef::Client {
         let render_state = Arc::new(Mutex::new(RenderState::default()));
+        #[cfg(target_os = "macos")]
+        let current_frame: Arc<Mutex<Option<CVPixelBuffer>>> = Arc::new(Mutex::new(None));
         let (popup_sender, _popup_receiver) = crate::events::event_channel();
-        ClientBuilder::build_for_popup(render_state, popup_sender)
+        ClientBuilder::build_for_popup(
+            render_state,
+            #[cfg(target_os = "macos")]
+            current_frame,
+            popup_sender,
+        )
     }
 }
 

--- a/crates/browser/src/render_handler.rs
+++ b/crates/browser/src/render_handler.rs
@@ -20,12 +20,12 @@ use io_surface::IOSurface;
 use parking_lot::Mutex;
 use std::sync::Arc;
 
+/// Viewport geometry shared between the GPUI resize path and CEF's view_rect/screen_info callbacks.
+/// Kept separate from the frame buffer so geometry reads never contend with 60fps frame writes.
 pub struct RenderState {
     pub width: u32,
     pub height: u32,
     pub scale_factor: f32,
-    #[cfg(target_os = "macos")]
-    pub current_frame: Option<CVPixelBuffer>,
 }
 
 impl Default for RenderState {
@@ -34,8 +34,6 @@ impl Default for RenderState {
             width: 800,
             height: 600,
             scale_factor: 1.0,
-            #[cfg(target_os = "macos")]
-            current_frame: None,
         }
     }
 }
@@ -44,14 +42,24 @@ impl Default for RenderState {
 pub struct OsrRenderHandler {
     state: Arc<Mutex<RenderState>>,
     #[cfg(target_os = "macos")]
+    current_frame: Arc<Mutex<Option<CVPixelBuffer>>>,
+    #[cfg(target_os = "macos")]
     sender: EventSender,
 }
 
 impl OsrRenderHandler {
-    pub fn new(state: Arc<Mutex<RenderState>>, sender: EventSender) -> Self {
+    pub fn new(
+        state: Arc<Mutex<RenderState>>,
+        #[cfg(target_os = "macos")] current_frame: Arc<Mutex<Option<CVPixelBuffer>>>,
+        sender: EventSender,
+    ) -> Self {
         #[cfg(target_os = "macos")]
         {
-            Self { state, sender }
+            Self {
+                state,
+                current_frame,
+                sender,
+            }
         }
 
         #[cfg(not(target_os = "macos"))]
@@ -153,7 +161,7 @@ wrap_render_handler! {
                     }
                 };
 
-                self.handler.state.lock().current_frame = Some(pixel_buffer);
+                *self.handler.current_frame.lock() = Some(pixel_buffer);
                 let _ = self.handler.sender.send(BrowserEvent::FrameReady);
             }
 

--- a/crates/browser/src/tab.rs
+++ b/crates/browser/src/tab.rs
@@ -105,6 +105,8 @@ pub struct BrowserTab {
     browser_id: Option<i32>,
     client: cef::Client,
     render_state: Arc<Mutex<RenderState>>,
+    #[cfg(target_os = "macos")]
+    current_frame: Arc<Mutex<Option<CVPixelBuffer>>>,
     event_receiver: EventReceiver,
     url: String,
     title: String,
@@ -127,13 +129,22 @@ impl EventEmitter<TabEvent> for BrowserTab {}
 impl BrowserTab {
     pub fn new(_cx: &mut Context<Self>) -> Self {
         let render_state = Arc::new(Mutex::new(RenderState::default()));
+        #[cfg(target_os = "macos")]
+        let current_frame: Arc<Mutex<Option<CVPixelBuffer>>> = Arc::new(Mutex::new(None));
         let (sender, receiver) = events::event_channel();
-        let client = ClientBuilder::build(render_state.clone(), sender);
+        let client = ClientBuilder::build(
+            render_state.clone(),
+            #[cfg(target_os = "macos")]
+            current_frame.clone(),
+            sender,
+        );
 
         Self {
             browser_id: None,
             client,
             render_state,
+            #[cfg(target_os = "macos")]
+            current_frame,
             event_receiver: receiver,
             url: String::from("glass://newtab"),
             title: String::from("New Tab"),
@@ -160,13 +171,22 @@ impl BrowserTab {
         _cx: &mut Context<Self>,
     ) -> Self {
         let render_state = Arc::new(Mutex::new(RenderState::default()));
+        #[cfg(target_os = "macos")]
+        let current_frame: Arc<Mutex<Option<CVPixelBuffer>>> = Arc::new(Mutex::new(None));
         let (sender, receiver) = events::event_channel();
-        let client = ClientBuilder::build(render_state.clone(), sender);
+        let client = ClientBuilder::build(
+            render_state.clone(),
+            #[cfg(target_os = "macos")]
+            current_frame.clone(),
+            sender,
+        );
 
         Self {
             browser_id: None,
             client,
             render_state,
+            #[cfg(target_os = "macos")]
+            current_frame,
             event_receiver: receiver,
             url,
             title,
@@ -225,7 +245,9 @@ impl BrowserTab {
                 }
                 #[cfg(target_os = "macos")]
                 BrowserEvent::FrameReady => {
-                    cx.emit(TabEvent::FrameReady);
+                    if !is_suspended {
+                        cx.emit(TabEvent::FrameReady);
+                    }
                 }
                 BrowserEvent::BrowserCreated => {}
                 BrowserEvent::LoadError { url, error_text } => {
@@ -672,7 +694,7 @@ impl BrowserTab {
 
     #[cfg(target_os = "macos")]
     pub fn current_frame(&self) -> Option<CVPixelBuffer> {
-        self.render_state.lock().current_frame.clone()
+        self.current_frame.lock().clone()
     }
 
     pub fn url(&self) -> &str {
@@ -768,7 +790,7 @@ impl BrowserTab {
         }
         #[cfg(target_os = "macos")]
         {
-            self.render_state.lock().current_frame = None;
+            *self.current_frame.lock() = None;
         }
     }
 


### PR DESCRIPTION
## Summary

Four targeted, low-risk improvements to the browser crate's rendering pipeline — no new dependencies, no behavior changes, purely less wasted work:

- **Gate `FrameReady` on suspension** (`tab.rs`): Skip emitting `TabEvent::FrameReady` for suspended tabs, matching the existing `is_suspended` guard on all other events.
- **Gate `FrameReady` notify on surface visibility** (`browser_view.rs`): Only call `cx.notify()` from `FrameReady` when `surface_state == Visible`. In-flight frames queued just before a mode switch no longer trigger layout work on the hidden browser view.
- **Split `RenderState` Mutex** (`render_handler.rs`, `tab.rs`, `client.rs`, `life_span_handler.rs`): Extract `current_frame: Option<CVPixelBuffer>` into its own `Arc<Mutex<...>>`. CEF's `view_rect`/`screen_info` geometry callbacks no longer share a lock with the 60fps `on_accelerated_paint` write path. Geometry queries and frame buffer writes now operate on independent locks — no contention between them.
- **Compute `pinned_count` once per render** (`tab_strip.rs`, `browser_view.rs`): Both `render_tab_strip` and `render_sidebar` previously performed independent `O(n)` scans over all tabs to count pinned ones. A `pinned_tab_count()` helper is now called once in `render()` and passed as a parameter to both methods.

## Test plan

- [x] `cargo check -p browser` passes with no errors
- [x] `cargo check -p workspace -p browser` passes
- [ ] Mode switching (browser → editor → terminal → browser) remains smooth with no stale frames
- [ ] Tab suspension/resume works correctly with no blank-frame artifacts

Release Notes:

- N/A